### PR TITLE
Add spotify-web-api-js w/ npm auto-update

### DIFF
--- a/packages/s/spotify-web-api-js.json
+++ b/packages/s/spotify-web-api-js.json
@@ -1,0 +1,26 @@
+{
+  "name": "spotify-web-api-js",
+  "description": "A client-side JS wrapper for the Spotify Web API",
+  "keywords": [
+    "spotify"
+  ],
+  "author": {
+    "name": "José M. Pérez"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/JMPerez/spotify-web-api-js",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/JMPerez/spotify-web-api-js.git"
+  },
+  "npmName": "spotify-web-api-js",
+  "npmFileMap": [
+    {
+      "basePath": "src",
+      "files": [
+        "**/*.@(js|ts)"
+      ]
+    }
+  ],
+  "filename": "spotify-web-api.js"
+}


### PR DESCRIPTION
Adding spotify-web-api-js using npm auto-update from NPM package spotify-web-api-js.

Resolves https://github.com/cdnjs/cdnjs/issues/12384.