### PR TITLE
Add react-big-calendar w/ npm auto-update

### DIFF
--- a/packages/r/react-big-calendar.json
+++ b/packages/r/react-big-calendar.json
@@ -1,0 +1,32 @@
+{
+  "name": "react-big-calendar",
+  "description": "Calendar! with events",
+  "keywords": [
+    "scheduler",
+    "react-component",
+    "react",
+    "calendar",
+    "events",
+    "full calendar"
+  ],
+  "author": {
+    "name": "Jason Quense",
+    "email": "monastic.panic@gmail.com"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/intljusticemission/react-big-calendar#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/intljusticemission/react-big-calendar.git"
+  },
+  "npmName": "react-big-calendar",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "*.js"
+      ]
+    }
+  ],
+  "filename": "react-big-calendar.min.js"
+}


### PR DESCRIPTION
Adding react-big-calendar using npm auto-update from NPM package react-big-calendar.

Resolves https://github.com/cdnjs/cdnjs/issues/12401.