### PR TITLE
Add mapbox.js w/ npm auto-update

### DIFF
--- a/packages/m/mapbox.js.json
+++ b/packages/m/mapbox.js.json
@@ -1,0 +1,24 @@
+{
+  "name": "mapbox.js",
+  "description": "Mapbox plugin for Leaflet",
+  "keywords": [],
+  "author": {
+    "name": "Mapbox"
+  },
+  "license": "BSD-3-Clause",
+  "homepage": "http://mapbox.com/",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/mapbox/mapbox.js.git"
+  },
+  "npmName": "mapbox.js",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "**/*.@(js|css|map|png|svg)"
+      ]
+    }
+  ],
+  "filename": "mapbox.js"
+}


### PR DESCRIPTION
Adding mapbox.js using npm auto-update from NPM package mapbox.js.

Resolves https://github.com/cdnjs/cdnjs/issues/12427.