### PR TITLE
Add bchaddrjs w/ npm auto-update

### DIFF
--- a/packages/b/bchaddrjs.json
+++ b/packages/b/bchaddrjs.json
@@ -1,0 +1,35 @@
+{
+  "name": "bchaddrjs",
+  "description": "Bitcoin Cash general purpose address translation.",
+  "keywords": [
+    "bitcoin-cash",
+    "bitcoin",
+    "bch",
+    "cryptocurrency",
+    "address",
+    "encoding",
+    "translation",
+    "base58",
+    "bitpay",
+    "cash-address"
+  ],
+  "author": {
+    "name": "Emilio Almansi",
+    "email": "hi@ealmansi.com"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/ealmansi/bchaddrjs#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/ealmansi/bchaddrjs.git"
+  },
+  "npmName": "bchaddrjs",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "*.js"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adding bchaddrjs using npm auto-update from NPM package bchaddrjs.

Resolves https://github.com/cdnjs/cdnjs/issues/12475.