### PR TITLE
Add lato-font w/ npm auto-update

### DIFF
--- a/packages/l/lato-font.json
+++ b/packages/l/lato-font.json
@@ -1,0 +1,26 @@
+{
+  "name": "lato-font",
+  "description": "Distribution repository for Lato font",
+  "keywords": [
+    "font"
+  ],
+  "author": "",
+  "license": "(MIT AND OFL-1.1)",
+  "homepage": "https://github.com/betsol/lato-font#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/betsol/lato-font.git"
+  },
+  "npmName": "lato-font",
+  "npmFileMap": [
+    {
+      "basePath": "",
+      "files": [
+        "css/*.css",
+        "fonts/**/*",
+        "scss/**/*.scss"
+      ]
+    }
+  ],
+  "filename": "css/lato-font.min.css"
+}


### PR DESCRIPTION
Adding lato-font using npm auto-update from NPM package lato-font.

Resolves https://github.com/cdnjs/cdnjs/issues/12582.