### PR TITLE
Add leaflet-geosearch w/ npm auto-update

### DIFF
--- a/packages/l/leaflet-geosearch.json
+++ b/packages/l/leaflet-geosearch.json
@@ -1,0 +1,32 @@
+{
+  "name": "leaflet-geosearch",
+  "description": "Adds support for address lookup (a.k.a. geocoding / geoseaching) to Leaflet.",
+  "keywords": [
+    "geolocation",
+    "geocoding",
+    "plugins",
+    "leaflet",
+    "geo",
+    "map"
+  ],
+  "author": {
+    "name": "Stephan Meijer",
+    "email": "stephan@meijer.ws"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/smeijer/leaflet-geosearch#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/smeijer/leaflet-geosearch.git"
+  },
+  "npmName": "leaflet-geosearch",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "*.@(js|css)"
+      ]
+    }
+  ],
+  "filename": "bundle.min.js"
+}


### PR DESCRIPTION
Adding leaflet-geosearch using npm auto-update from NPM package leaflet-geosearch.

Resolves https://github.com/cdnjs/cdnjs/issues/12618.