### PR TITLE
Add jasmine-marbles w/ npm auto-update

### DIFF
--- a/packages/j/jasmine-marbles.json
+++ b/packages/j/jasmine-marbles.json
@@ -1,0 +1,19 @@
+{
+  "name": "jasmine-marbles",
+  "description": "Marble testing helpers for RxJS and Jasmine",
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "homepage": "",
+  "repository": {},
+  "npmName": "jasmine-marbles",
+  "npmFileMap": [
+    {
+      "basePath": "bundles",
+      "files": [
+        "*.js"
+      ]
+    }
+  ],
+  "filename": "jasmine-marbles.umd.js"
+}

--- a/packages/j/jasmine-marbles.json
+++ b/packages/j/jasmine-marbles.json
@@ -1,11 +1,19 @@
 {
   "name": "jasmine-marbles",
   "description": "Marble testing helpers for RxJS and Jasmine",
-  "keywords": [],
-  "author": "",
+  "keywords": [
+    "rxjs",
+    "observables",
+    "jasmine",
+    "unit-testing"
+  ],
+  "author": "Synapse Wireless Labs",
   "license": "MIT",
-  "homepage": "",
-  "repository": {},
+  "homepage": "https://github.com/synapse-wireless-labs/jasmine-marbles#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/synapse-wireless-labs/jasmine-marbles.git"
+  },
   "npmName": "jasmine-marbles",
   "npmFileMap": [
     {


### PR DESCRIPTION
Adding jasmine-marbles using npm auto-update from NPM package jasmine-marbles.

Resolves https://github.com/cdnjs/cdnjs/issues/12627.