### PR TITLE
Add startbootstrap-sb-admin w/ npm auto-update

### DIFF
--- a/packages/s/startbootstrap-sb-admin.json
+++ b/packages/s/startbootstrap-sb-admin.json
@@ -1,0 +1,35 @@
+{
+  "name": "startbootstrap-sb-admin",
+  "description": "A one page app landing page HTML theme for Bootstrap.",
+  "keywords": [
+    "css",
+    "sass",
+    "html",
+    "responsive",
+    "theme",
+    "template",
+    "admin",
+    "app"
+  ],
+  "author": {
+    "name": "Start Bootstrap"
+  },
+  "license": "MIT",
+  "homepage": "https://startbootstrap.com/template-overviews/sb-admin",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BlackrockDigital/startbootstrap-sb-admin.git"
+  },
+  "npmName": "startbootstrap-sb-admin",
+  "npmFileMap": [
+    {
+      "basePath": "",
+      "files": [
+        "css/*.css",
+        "js/*.js",
+        "scss/*.scss"
+      ]
+    }
+  ],
+  "filename": "css/sb-admin.min.css"
+}


### PR DESCRIPTION
Adding startbootstrap-sb-admin using npm auto-update from NPM package startbootstrap-sb-admin.

Resolves https://github.com/cdnjs/cdnjs/issues/12632.