### PR TITLE
Add csslint w/ npm auto-update

### DIFF
--- a/packages/c/csslint.json
+++ b/packages/c/csslint.json
@@ -1,0 +1,24 @@
+{
+  "name": "csslint",
+  "description": "CSSLint",
+  "keywords": [],
+  "author": {
+    "name": "Nicole Sullivan"
+  },
+  "license": "MIT",
+  "homepage": "http://csslint.net/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/CSSLint/csslint.git"
+  },
+  "npmName": "csslint",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "*.js"
+      ]
+    }
+  ],
+  "filename": "csslint.js"
+}

--- a/packages/c/csslint.json
+++ b/packages/c/csslint.json
@@ -1,10 +1,13 @@
 {
   "name": "csslint",
-  "description": "CSSLint",
-  "keywords": [],
-  "author": {
-    "name": "Nicole Sullivan"
-  },
+  "description": "Automated linting of Cascading Stylesheets",
+  "keywords": [
+    "css",
+    "styling",
+    "lint",
+    "linting"
+  ],
+  "author": "Nicole Sullivan",
   "license": "MIT",
   "homepage": "http://csslint.net/",
   "repository": {


### PR DESCRIPTION
Adding csslint using npm auto-update from NPM package csslint.

Resolves https://github.com/cdnjs/cdnjs/issues/12668.