### PR TITLE
Add i18next-localstorage-cache w/ npm auto-update

### DIFF
--- a/packages/i/i18next-localstorage-cache.json
+++ b/packages/i/i18next-localstorage-cache.json
@@ -12,7 +12,10 @@
   },
   "license": "MIT",
   "homepage": "https://github.com/i18next/i18next-localStorage-cache",
-  "repository": {},
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/i18next/i18next-localStorage-cache.git"
+  },
   "npmName": "i18next-localstorage-cache",
   "npmFileMap": [
     {

--- a/packages/i/i18next-localstorage-cache.json
+++ b/packages/i/i18next-localstorage-cache.json
@@ -1,0 +1,32 @@
+{
+  "name": "i18next-localstorage-cache",
+  "description": "caching layer for i18next using browsers localStorage",
+  "keywords": [
+    "i18next",
+    "i18next-cache"
+  ],
+  "author": {
+    "name": "Jan Mühlemann",
+    "email": "jan.muehlemann@gmail.com",
+    "url": "https://github.com/jamuhl"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/i18next/i18next-localStorage-cache",
+  "repository": {},
+  "npmName": "i18next-localstorage-cache",
+  "npmFileMap": [
+    {
+      "basePath": "dist/umd",
+      "files": [
+        "*.js"
+      ]
+    },
+    {
+      "basePath": "dist",
+      "files": [
+        "@(commonjs|es)/*.js"
+      ]
+    }
+  ],
+  "filename": "i18nextLocalStorageCache.min.js"
+}


### PR DESCRIPTION
Adding i18next-localstorage-cache using npm auto-update from NPM package i18next-localstorage-cache.

Resolves https://github.com/cdnjs/cdnjs/issues/12669.