### PR TITLE
Add react-dates w/ npm auto-update

### DIFF
--- a/packages/r/react-dates.json
+++ b/packages/r/react-dates.json
@@ -1,0 +1,25 @@
+{
+  "name": "react-dates",
+  "description": "A responsive and accessible date range picker component built with React",
+  "keywords": [],
+  "author": {
+    "name": "Maja Wichrowska",
+    "email": "maja.wichrowska@airbnb.com"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/airbnb/react-dates#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/airbnb/react-dates.git"
+  },
+  "npmName": "react-dates",
+  "npmFileMap": [
+    {
+      "basePath": "lib",
+      "files": [
+        "**/*.@(js|css)"
+      ]
+    }
+  ],
+  "filename": "index.js"
+}


### PR DESCRIPTION
Adding react-dates using npm auto-update from NPM package react-dates.

Resolves https://github.com/cdnjs/cdnjs/issues/12693.