### PR TITLE
Add idb-keyval w/ npm auto-update

### DIFF
--- a/packages/i/idb-keyval.json
+++ b/packages/i/idb-keyval.json
@@ -1,0 +1,32 @@
+{
+  "name": "idb-keyval",
+  "description": "A super-simple-small keyval store built on top of IndexedDB",
+  "keywords": [
+    "idb",
+    "indexeddb",
+    "store",
+    "keyval",
+    "localstorage",
+    "storage",
+    "promise"
+  ],
+  "author": {
+    "name": "Jake Archibald"
+  },
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/jakearchibald/idb-keyval#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jakearchibald/idb-keyval.git"
+  },
+  "npmName": "idb-keyval",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "*.@(js|ts)"
+      ]
+    }
+  ],
+  "filename": "idb-keyval-cjs-compat.min.js"
+}


### PR DESCRIPTION
Adding idb-keyval using npm auto-update from NPM package idb-keyval.

Resolves https://github.com/cdnjs/cdnjs/issues/12700.