### PR TITLE
Add angularjs-google-maps w/ npm auto-update

### DIFF
--- a/packages/a/angularjs-google-maps.json
+++ b/packages/a/angularjs-google-maps.json
@@ -1,0 +1,22 @@
+{
+  "name": "angularjs-google-maps",
+  "description": "The Simplest AngularJS Google Maps V3 Directive",
+  "keywords": [],
+  "author": "",
+  "license": "",
+  "homepage": "https://github.com/allenhwkim/angularjs-google-maps#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/allenhwkim/angularjs-google-maps.git"
+  },
+  "npmName": "ngmap",
+  "npmFileMap": [
+    {
+      "basePath": "build/scripts",
+      "files": [
+        "*.js"
+      ]
+    }
+  ],
+  "filename": "ng-map.min.js"
+}

--- a/packages/a/angularjs-google-maps.json
+++ b/packages/a/angularjs-google-maps.json
@@ -1,9 +1,12 @@
 {
   "name": "angularjs-google-maps",
   "description": "The Simplest AngularJS Google Maps V3 Directive",
-  "keywords": [],
-  "author": "",
-  "license": "",
+  "keywords": [
+    "angular",
+    "markers"
+  ],
+  "author": "allenhwkim",
+  "license": "MIT",
   "homepage": "https://github.com/allenhwkim/angularjs-google-maps#readme",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adding angularjs-google-maps using npm auto-update from NPM package ngmap.

Resolves https://github.com/cdnjs/cdnjs/issues/12716.