### PR TITLE
Add vue-disqus w/ npm auto-update

### DIFF
--- a/packages/v/vue-disqus.json
+++ b/packages/v/vue-disqus.json
@@ -8,8 +8,7 @@
   ],
   "author": {
     "name": "Alan Albuquerque",
-    "email": "ktquez@gmail.com",
-    "url": "ktquez"
+    "email": "ktquez@gmail.com"
   },
   "license": "MIT",
   "homepage": "https://github.com/ktquez/vue-disqus#readme",

--- a/packages/v/vue-disqus.json
+++ b/packages/v/vue-disqus.json
@@ -1,0 +1,30 @@
+{
+  "name": "vue-disqus",
+  "description": "Vue component to integrate Disqus comments in your application, with support for SPA",
+  "keywords": [
+    "disqus",
+    "vue",
+    "comments"
+  ],
+  "author": {
+    "name": "Alan Albuquerque",
+    "email": "ktquez@gmail.com",
+    "url": "ktquez"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/ktquez/vue-disqus#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ktquez/vue-disqus.git"
+  },
+  "npmName": "vue-disqus",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "*.js"
+      ]
+    }
+  ],
+  "filename": "vue-disqus.js"
+}


### PR DESCRIPTION
Adding vue-disqus using npm auto-update from NPM package vue-disqus.

Resolves https://github.com/cdnjs/cdnjs/issues/12719.