### PR TITLE
Add react-spring w/ npm auto-update

### DIFF
--- a/packages/r/react-spring.json
+++ b/packages/r/react-spring.json
@@ -1,0 +1,29 @@
+{
+  "name": "react-spring",
+  "description": "A set of spring-physics based animation primitives",
+  "keywords": [
+    "react",
+    "motion",
+    "animated",
+    "animation",
+    "spring"
+  ],
+  "author": {
+    "name": "Paul Henschel"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/drcmda/react-spring#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/drcmda/react-spring.git"
+  },
+  "npmName": "react-spring",
+  "npmFileMap": [
+    {
+      "basePath": "",
+      "files": [
+        "*.@(js|ts)"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adding react-spring using npm auto-update from NPM package react-spring.

Resolves https://github.com/cdnjs/cdnjs/issues/12728.