### PR TITLE
Add editor-md w/ npm auto-update

### DIFF
--- a/packages/e/editor-md.json
+++ b/packages/e/editor-md.json
@@ -1,0 +1,28 @@
+{
+  "name": "editor-md",
+  "description": "Open source online markdown editor.",
+  "keywords": [
+    "editor.md",
+    "markdown",
+    "editor"
+  ],
+  "author": {
+    "name": "Pandao"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/pandao/editor.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pandao/editor.md.git"
+  },
+  "npmName": "editor.md",
+  "npmFileMap": [
+    {
+      "basePath": "",
+      "files": [
+        "editormd*.js"
+      ]
+    }
+  ],
+  "filename": "editormd.min.js"
+}


### PR DESCRIPTION
Adding editor-md using npm auto-update from NPM package editor.md.

Resolves https://github.com/cdnjs/cdnjs/issues/12736.