### PR TITLE
Add github-buttons w/ npm auto-update

### DIFF
--- a/packages/g/github-buttons.json
+++ b/packages/g/github-buttons.json
@@ -1,0 +1,31 @@
+{
+  "name": "github-buttons",
+  "description": "GitHub Buttons",
+  "keywords": [
+    "github",
+    "button",
+    "frontend",
+    "component"
+  ],
+  "author": {
+    "name": "なつき",
+    "email": "i@ntk.me",
+    "url": "https://ntk.me/"
+  },
+  "license": "BSD-2-Clause",
+  "homepage": "https://buttons.github.io/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ntkme/github-buttons.git"
+  },
+  "npmName": "github-buttons",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "*.@(js|ts)"
+      ]
+    }
+  ],
+  "filename": "buttons.min.js"
+}


### PR DESCRIPTION
Adding github-buttons using npm auto-update from NPM package github-buttons.

Resolves https://github.com/cdnjs/cdnjs/issues/12743.