### PR TITLE
Add cookieconsent w/ npm auto-update

### DIFF
--- a/packages/c/cookieconsent.json
+++ b/packages/c/cookieconsent.json
@@ -1,0 +1,24 @@
+{
+  "name": "cookieconsent",
+  "description": "Osano cookie consent tool.",
+  "keywords": [],
+  "author": {
+    "name": "Osano, Inc., a Public Benefit Corporation"
+  },
+  "license": "MIT",
+  "homepage": "http://cookieconsent.osano.com/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/osano/cookieconsent.git"
+  },
+  "npmName": "cookieconsent",
+  "npmFileMap": [
+    {
+      "basePath": "build",
+      "files": [
+        "*.@(js|css)"
+      ]
+    }
+  ],
+  "filename": "cookieconsent.min.js"
+}


### PR DESCRIPTION
Adding cookieconsent using npm auto-update from NPM package cookieconsent.

Resolves https://github.com/cdnjs/cdnjs/issues/12823.