### PR TITLE
Add react-jsonschema-form w/ npm auto-update

### DIFF
--- a/packages/r/react-jsonschema-form.json
+++ b/packages/r/react-jsonschema-form.json
@@ -1,0 +1,29 @@
+{
+  "name": "react-jsonschema-form",
+  "description": "A simple React component capable of building HTML forms out of a JSON schema.",
+  "keywords": [
+    "react",
+    "form",
+    "json-schema"
+  ],
+  "author": {
+    "name": "Nicolas Perriault",
+    "email": "nperriault@mozilla.com"
+  },
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/mozilla-services/react-jsonschema-form#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mozilla-services/react-jsonschema-form.git"
+  },
+  "npmName": "react-jsonschema-form",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "*.@(js|map)"
+      ]
+    }
+  ],
+  "filename": "react-jsonschema-form.js"
+}


### PR DESCRIPTION
Adding react-jsonschema-form using npm auto-update from NPM package react-jsonschema-form.

Resolves https://github.com/cdnjs/cdnjs/issues/12827.