### PR TITLE
Add base w/ npm auto-update

### DIFF
--- a/packages/b/base.json
+++ b/packages/b/base.json
@@ -1,0 +1,32 @@
+{
+  "name": "base",
+  "description": "A Rock Solid, Responsive CSS Framework built to work on all devices big, small and in-between.",
+  "keywords": [
+    "css",
+    "scss",
+    "less",
+    "framework",
+    "mobile-first",
+    "lightweight",
+    "responsive"
+  ],
+  "author": {
+    "name": "Matthew Hartman"
+  },
+  "license": "MIT",
+  "homepage": "http://getbase.org/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getbase/base.git"
+  },
+  "npmName": "@getbase/base",
+  "npmFileMap": [
+    {
+      "basePath": "",
+      "files": [
+        "**/*.@(css|scss)"
+      ]
+    }
+  ],
+  "filename": "index.css"
+}


### PR DESCRIPTION
Adding base using npm auto-update from NPM package @getbase/base.

Resolves https://github.com/cdnjs/cdnjs/issues/12832.