### PR TITLE
Add ua-device-detector w/ npm auto-update

### DIFF
--- a/packages/u/ua-device-detector.json
+++ b/packages/u/ua-device-detector.json
@@ -1,0 +1,26 @@
+{
+  "name": "ua-device-detector",
+  "description": "Parses user-agent to set css classes or directly usable via JS / NodeJS.",
+  "keywords": [
+    "angularjs"
+  ],
+  "author": {
+    "name": "srfrnk"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/srfrnk/ua-device-detector",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/srfrnk/ua-device-detector.git"
+  },
+  "npmName": "ua-device-detector",
+  "npmFileMap": [
+    {
+      "basePath": "",
+      "files": [
+        "ua-device-detector*.js"
+      ]
+    }
+  ],
+  "filename": "ua-device-detector.min.js"
+}


### PR DESCRIPTION
Adding ua-device-detector using npm auto-update from NPM package ua-device-detector.

Resolves https://github.com/cdnjs/cdnjs/issues/12914.