### PR TITLE
Add js-combinatorics w/ npm auto-update

### DIFF
--- a/packages/j/js-combinatorics.json
+++ b/packages/j/js-combinatorics.json
@@ -1,0 +1,28 @@
+{
+  "name": "js-combinatorics",
+  "description": "Simple combinatorics like power set, combination, and permutation in JavaScript",
+  "keywords": [
+    "Combinatorics",
+    "combination",
+    "permutation"
+  ],
+  "author": {
+    "name": "Dan Kogai"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/dankogai/js-combinatorics#readme",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/dankogai/js-combinatorics.git"
+  },
+  "npmName": "js-combinatorics",
+  "npmFileMap": [
+    {
+      "basePath": "",
+      "files": [
+        "combinatorics.js"
+      ]
+    }
+  ],
+  "filename": "combinatorics.js"
+}


### PR DESCRIPTION
Adding js-combinatorics using npm auto-update from NPM package js-combinatorics.

Resolves https://github.com/cdnjs/cdnjs/issues/12949.