### PR TITLE
Add getmdl-select w/ npm auto-update

### DIFF
--- a/packages/g/getmdl-select.json
+++ b/packages/g/getmdl-select.json
@@ -1,0 +1,32 @@
+{
+  "name": "getmdl-select",
+  "description": "select for material-design-lite",
+  "keywords": [
+    "material",
+    "mdl",
+    "getmdl",
+    "select",
+    "getmdl-select",
+    "dropdown",
+    "getmdl-dropdown"
+  ],
+  "author": {
+    "name": "CreativeIT"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/CreativeIT/getmdl-select#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/CreativeIT/getmdl-select.git"
+  },
+  "npmName": "getmdl-select",
+  "npmFileMap": [
+    {
+      "basePath": "",
+      "files": [
+        "getmdl-select*.@(js|css|map)"
+      ]
+    }
+  ],
+  "filename": "getmdl-select.min.js"
+}


### PR DESCRIPTION
Adding getmdl-select using npm auto-update from NPM package getmdl-select.

Resolves https://github.com/cdnjs/cdnjs/issues/12951.