### PR TITLE
Add prunecluster w/ npm auto-update

### DIFF
--- a/packages/p/prunecluster.json
+++ b/packages/p/prunecluster.json
@@ -8,7 +8,7 @@
     "marker",
     "realtime"
   ],
-  "author": "",
+  "author": "SINTEF-9012",
   "license": "MIT",
   "homepage": "https://github.com/SINTEF-9012/PruneCluster",
   "repository": {

--- a/packages/p/prunecluster.json
+++ b/packages/p/prunecluster.json
@@ -1,0 +1,28 @@
+{
+  "name": "prunecluster",
+  "description": "Fast and realtime marker clustering for Leaflet",
+  "keywords": [
+    "map",
+    "clustering",
+    "leaflet",
+    "marker",
+    "realtime"
+  ],
+  "author": "",
+  "license": "MIT",
+  "homepage": "https://github.com/SINTEF-9012/PruneCluster",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/SINTEF-9012/PruneCluster.git"
+  },
+  "npmName": "prunecluster",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "*.@(js|css|ts)"
+      ]
+    }
+  ],
+  "filename": "PruneCluster.js"
+}


### PR DESCRIPTION
Adding prunecluster using npm auto-update from NPM package prunecluster.

Resolves https://github.com/cdnjs/cdnjs/issues/13028.