### PR TITLE
Add tarteaucitronjs w/ npm auto-update

### DIFF
--- a/packages/t/tarteaucitronjs.json
+++ b/packages/t/tarteaucitronjs.json
@@ -1,0 +1,30 @@
+{
+  "name": "tarteaucitronjs",
+  "description": "Comply to the European cookie law",
+  "keywords": [
+    "cookie",
+    "law",
+    "rgpd",
+    "gdpr",
+    "cookie"
+  ],
+  "author": {
+    "name": "AIC Agency SAS"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/AmauriC/tarteaucitron.js#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/AmauriC/tarteaucitron.js.git"
+  },
+  "npmName": "tarteaucitronjs",
+  "npmFileMap": [
+    {
+      "basePath": "",
+      "files": [
+        "**/*.@(js|css)"
+      ]
+    }
+  ],
+  "filename": "tarteaucitron.js"
+}


### PR DESCRIPTION
Adding tarteaucitronjs using npm auto-update from NPM package tarteaucitronjs.

Resolves https://github.com/cdnjs/cdnjs/issues/13066.