### PR TITLE
Add cytoscape-popper w/ npm auto-update

### DIFF
--- a/packages/c/cytoscape-popper.json
+++ b/packages/c/cytoscape-popper.json
@@ -1,0 +1,27 @@
+{
+  "name": "cytoscape-popper",
+  "description": "A Cytoscape.js extension for Popper.js",
+  "keywords": [
+    "cytoscape",
+    "cytoscape-extension"
+  ],
+  "author": {
+    "name": "Cytoscape"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/cytoscape/cytoscape.js-popper",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cytoscape/cytoscape.js-popper.git"
+  },
+  "npmName": "cytoscape-popper",
+  "npmFileMap": [
+    {
+      "basePath": "",
+      "files": [
+        "cytoscape-popper.js"
+      ]
+    }
+  ],
+  "filename": "cytoscape-popper.js"
+}


### PR DESCRIPTION
Adding cytoscape-popper using npm auto-update from NPM package cytoscape-popper.

Resolves https://github.com/cdnjs/cdnjs/issues/13069.