### PR TITLE
Add glider-js w/ npm auto-update

### DIFF
--- a/packages/g/glider-js.json
+++ b/packages/g/glider-js.json
@@ -1,0 +1,29 @@
+{
+  "name": "glider-js",
+  "description": "A fast, lightweight carousel alternative",
+  "keywords": [
+    "carousel",
+    "scrolling",
+    "list",
+    "paging"
+  ],
+  "author": {
+    "name": "Nick Piscitelli"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/NickPiscitelli/Glider.js#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/NickPiscitelli/Glider.js.git"
+  },
+  "npmName": "glider-js",
+  "npmFileMap": [
+    {
+      "basePath": "",
+      "files": [
+        "glider*.@(js|css)"
+      ]
+    }
+  ],
+  "filename": "glider.min.js"
+}


### PR DESCRIPTION
Adding glider-js using npm auto-update from NPM package glider-js.

Resolves https://github.com/cdnjs/cdnjs/issues/13094.