### PR TITLE
Add navigo w/ npm auto-update

### DIFF
--- a/packages/n/navigo.json
+++ b/packages/n/navigo.json
@@ -1,0 +1,31 @@
+{
+  "name": "navigo",
+  "description": "A simple vanilla JavaScript router with a fallback for older browsers",
+  "keywords": [
+    "router",
+    "vanilla",
+    "hash",
+    "history"
+  ],
+  "author": {
+    "name": "Krasimir Tsonev",
+    "email": "info@krasimirtsonev.com",
+    "url": "http://krasimirtsonev.com"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/krasimir/navigo#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/krasimir/navigo.git"
+  },
+  "npmName": "navigo",
+  "npmFileMap": [
+    {
+      "basePath": "lib",
+      "files": [
+        "*.@(js|map)"
+      ]
+    }
+  ],
+  "filename": "navigo.min.js"
+}


### PR DESCRIPTION
Adding navigo using npm auto-update from NPM package navigo.

Resolves https://github.com/cdnjs/cdnjs/issues/13124.