### PR TITLE
Add react-flip-toolkit w/ npm auto-update

### DIFF
--- a/packages/r/react-flip-toolkit.json
+++ b/packages/r/react-flip-toolkit.json
@@ -1,0 +1,29 @@
+{
+  "name": "react-flip-toolkit",
+  "description": "Configurable FLIP animation helpers for React",
+  "keywords": [
+    "react-component",
+    "FLIP",
+    "transition",
+    "animation"
+  ],
+  "author": {
+    "name": "Alex Holachek"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/aholachek/react-flip-toolkit#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aholachek/react-flip-toolkit.git"
+  },
+  "npmName": "react-flip-toolkit",
+  "npmFileMap": [
+    {
+      "basePath": "lib",
+      "files": [
+        "**/*.@(js|ts|map)"
+      ]
+    }
+  ],
+  "filename": "index.umd.js"
+}


### PR DESCRIPTION
Adding react-flip-toolkit using npm auto-update from NPM package react-flip-toolkit.

Resolves https://github.com/cdnjs/cdnjs/issues/13176.