### PR TITLE
Add node-snackbar w/ npm auto-update

### DIFF
--- a/packages/n/node-snackbar.json
+++ b/packages/n/node-snackbar.json
@@ -1,0 +1,28 @@
+{
+  "name": "node-snackbar",
+  "description": "Notifications inspired by Google Material Design",
+  "keywords": [
+    "snackbar",
+    "matieral-design",
+    "toast"
+  ],
+  "author": {
+    "name": "Chris Brame"
+  },
+  "license": "MIT",
+  "homepage": "http://www.polonel.com/snackbar",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/polonel/SnackBar.git"
+  },
+  "npmName": "node-snackbar",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "*.@(js|css|map)"
+      ]
+    }
+  ],
+  "filename": "snackbar.min.js"
+}


### PR DESCRIPTION
Adding node-snackbar using npm auto-update from NPM package node-snackbar.

Resolves https://github.com/cdnjs/cdnjs/issues/13188.