### PR TITLE
Add chartjs-plugin-doughnutlabel w/ npm auto-update

### DIFF
--- a/packages/c/chartjs-plugin-doughnutlabel.json
+++ b/packages/c/chartjs-plugin-doughnutlabel.json
@@ -4,7 +4,7 @@
   "keywords": [
     "chartjs",
     "chartjs-plugin",
-    "chartjs-doughnut".
+    "chartjs-doughnut",
     "javascript",
     "doughnut",
     "doughnut-chart"

--- a/packages/c/chartjs-plugin-doughnutlabel.json
+++ b/packages/c/chartjs-plugin-doughnutlabel.json
@@ -1,0 +1,22 @@
+{
+  "name": "chartjs-plugin-doughnutlabel",
+  "description": "Chart.js plugin for doughnut chart to display lines of text in the center",
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "homepage": "https://github.com/ciprianciurea/chartjs-plugin-doughnutlabel#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ciprianciurea/chartjs-plugin-doughnutlabel.git"
+  },
+  "npmName": "chartjs-plugin-doughnutlabel",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "*.js"
+      ]
+    }
+  ],
+  "filename": "chartjs-plugin-doughnutlabel.js"
+}

--- a/packages/c/chartjs-plugin-doughnutlabel.json
+++ b/packages/c/chartjs-plugin-doughnutlabel.json
@@ -1,8 +1,15 @@
 {
   "name": "chartjs-plugin-doughnutlabel",
   "description": "Chart.js plugin for doughnut chart to display lines of text in the center",
-  "keywords": [],
-  "author": "",
+  "keywords": [
+    "chartjs",
+    "chartjs-plugin",
+    "chartjs-doughnut".
+    "javascript",
+    "doughnut",
+    "doughnut-chart"
+  ],
+  "author": "Ciprian Ciurea",
   "license": "ISC",
   "homepage": "https://github.com/ciprianciurea/chartjs-plugin-doughnutlabel#readme",
   "repository": {


### PR DESCRIPTION
Adding chartjs-plugin-doughnutlabel using npm auto-update from NPM package chartjs-plugin-doughnutlabel.

Resolves https://github.com/cdnjs/cdnjs/issues/13273.