### PR TITLE
Add emoji-datasource-facebook w/ npm auto-update

### DIFF
--- a/packages/e/emoji-datasource-facebook.json
+++ b/packages/e/emoji-datasource-facebook.json
@@ -1,0 +1,28 @@
+{
+  "name": "emoji-datasource-facebook",
+  "description": "Emoji data and images - facebook",
+  "keywords": [
+    "emoji"
+  ],
+  "author": {
+    "name": "Cal Henderson",
+    "email": "cal@iamcal.com"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/iamcal/emoji-data",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/iamcal/emoji-data.git"
+  },
+  "npmName": "emoji-datasource-facebook",
+  "npmFileMap": [
+    {
+      "basePath": "",
+      "files": [
+        "emoji*.json",
+        "**/*.png"
+      ]
+    }
+  ],
+  "filename": "emoji.json"
+}


### PR DESCRIPTION
Adding emoji-datasource-facebook using npm auto-update from NPM package emoji-datasource-facebook.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13291.