### PR TITLE
Add emoji-datasource-messenger w/ npm auto-update

### DIFF
--- a/packages/e/emoji-datasource-messenger.json
+++ b/packages/e/emoji-datasource-messenger.json
@@ -1,0 +1,28 @@
+{
+  "name": "emoji-datasource-messenger",
+  "description": "Emoji data and images - messenger",
+  "keywords": [
+    "emoji"
+  ],
+  "author": {
+    "name": "Cal Henderson",
+    "email": "cal@iamcal.com"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/iamcal/emoji-data",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/iamcal/emoji-data.git"
+  },
+  "npmName": "emoji-datasource-messenger",
+  "npmFileMap": [
+    {
+      "basePath": "",
+      "files": [
+        "emoji*.json",
+        "**/*.png"
+      ]
+    }
+  ],
+  "filename": "emoji.json"
+}


### PR DESCRIPTION
Adding emoji-datasource-messenger using npm auto-update from NPM package emoji-datasource-messenger.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13291.