### PR TITLE
Add m3u8-parser w/ npm auto-update

### DIFF
--- a/packages/m/m3u8-parser.json
+++ b/packages/m/m3u8-parser.json
@@ -1,0 +1,27 @@
+{
+  "name": "m3u8-parser",
+  "description": "m3u8 parser",
+  "keywords": [
+    "videojs",
+    "videojs-plugin"
+  ],
+  "author": {
+    "name": "Brightcove, Inc"
+  },
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/videojs/m3u8-parser#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/videojs/m3u8-parser.git"
+  },
+  "npmName": "m3u8-parser",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "*.js"
+      ]
+    }
+  ],
+  "filename": "m3u8-parser.min.js"
+}


### PR DESCRIPTION
Adding m3u8-parser using npm auto-update from NPM package m3u8-parser.

Resolves https://github.com/cdnjs/cdnjs/issues/13336.