### PR TITLE
Add ramda-adjunct w/ npm auto-update

### DIFF
--- a/packages/r/ramda-adjunct.json
+++ b/packages/r/ramda-adjunct.json
@@ -1,0 +1,38 @@
+{
+  "name": "ramda-adjunct",
+  "description": "Ramda Adjunct is the most popular and most comprehensive set of utilities for use with Ramda, providing a variety of useful, well tested functions with excellent documentation.",
+  "keywords": [
+    "ramda",
+    "utils",
+    "utilities",
+    "toolkit",
+    "extensions",
+    "addons",
+    "adjunct",
+    "recipes",
+    "extras",
+    "cookbook",
+    "functional"
+  ],
+  "author": {
+    "name": "Vladimir Gorej",
+    "email": "vladimir.gorej@gmail.com",
+    "url": "https://www.linkedin.com/in/vladimirgorej/"
+  },
+  "license": "BSD-3-Clause",
+  "homepage": "https://github.com/char0n/ramda-adjunct",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/char0n/ramda-adjunct.git"
+  },
+  "npmName": "ramda-adjunct",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "*.js"
+      ]
+    }
+  ],
+  "filename": "RA.web.standalone.min.js"
+}


### PR DESCRIPTION
Adding ramda-adjunct using npm auto-update from NPM package ramda-adjunct.

Resolves https://github.com/cdnjs/cdnjs/issues/13337.