### PR TITLE
Add mailgo w/ npm auto-update

### DIFF
--- a/packages/m/mailgo.json
+++ b/packages/m/mailgo.json
@@ -1,0 +1,36 @@
+{
+  "name": "mailgo",
+  "description": "a different mailto: and another tel:",
+  "keywords": [
+    "mailto",
+    "mail",
+    "tel",
+    "callto",
+    "gmail",
+    "outlook",
+    "telegram",
+    "whatsapp",
+    "skype"
+  ],
+  "author": {
+    "name": "Matteo Manzinello",
+    "email": "matteo@manzinello.dev",
+    "url": "https://matteomanzinello.com"
+  },
+  "license": "MIT",
+  "homepage": "https://mailgo.js.org",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/manzinello/mailgo.git"
+  },
+  "npmName": "mailgo",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "*.@(js|css)"
+      ]
+    }
+  ],
+  "filename": "mailgo.min.js"
+}


### PR DESCRIPTION
Adding mailgo using npm auto-update from NPM package mailgo.

Resolves https://github.com/cdnjs/cdnjs/issues/13375.