### PR TITLE
Add vimeo-player w/ npm auto-update

### DIFF
--- a/packages/v/vimeo-player.json
+++ b/packages/v/vimeo-player.json
@@ -11,12 +11,9 @@
     "javascript",
     "postMessage"
   ],
-  "author": {
-    "name": "Vimeo",
-    "email": "https://vimeo.com"
-  },
+  "author": "Vimeo (https://vimeo.com)",
   "license": "MIT",
-  "homepage": "",
+  "homepage": "https://github.com/vimeo/player.js#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/vimeo/player.js.git"

--- a/packages/v/vimeo-player.json
+++ b/packages/v/vimeo-player.json
@@ -1,0 +1,34 @@
+{
+  "name": "vimeo-player",
+  "description": "Interact with and control an embedded Vimeo Player.",
+  "keywords": [
+    "vimeo",
+    "player",
+    "api",
+    "iframe",
+    "embed",
+    "video",
+    "javascript",
+    "postMessage"
+  ],
+  "author": {
+    "name": "Vimeo",
+    "email": "https://vimeo.com"
+  },
+  "license": "MIT",
+  "homepage": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vimeo/player.js.git"
+  },
+  "npmName": "@vimeo/player",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "*.@(js|map)"
+      ]
+    }
+  ],
+  "filename": "player.min.js"
+}


### PR DESCRIPTION
Adding vimeo-player using npm auto-update from NPM package @vimeo/player.

Resolves https://github.com/cdnjs/cdnjs/issues/13383.