### PR TITLE
Add datatables.net-responsive w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-responsive.json
+++ b/packages/d/datatables.net-responsive.json
@@ -1,0 +1,31 @@
+{
+  "name": "datatables.net-responsive",
+  "description": "Responsive for DataTables ",
+  "keywords": [
+    "responsive",
+    "DataTables",
+    "jQuery",
+    "table",
+    "DataTables"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-Responsive.git"
+  },
+  "npmName": "datatables.net-responsive",
+  "npmFileMap": [
+    {
+      "basePath": "js",
+      "files": [
+        "*.js"
+      ]
+    }
+  ],
+  "filename": "dataTables.responsive.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-responsive using npm auto-update from NPM package datatables.net-responsive.

Resolves https://github.com/cdnjs/cdnjs/issues/13633.