### PR TITLE
Add mqtt w/ npm auto-update

### DIFF
--- a/packages/m/mqtt.json
+++ b/packages/m/mqtt.json
@@ -1,0 +1,27 @@
+{
+  "name": "mqtt",
+  "description": "A library for the MQTT protocol",
+  "keywords": [
+    "mqtt",
+    "publish/subscribe",
+    "publish",
+    "subscribe"
+  ],
+  "author": "",
+  "license": "MIT",
+  "homepage": "https://github.com/mqttjs/MQTT.js#readme",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/mqttjs/MQTT.js.git"
+  },
+  "npmName": "mqtt",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "*.js"
+      ]
+    }
+  ],
+  "filename": "mqtt.min.js"
+}

--- a/packages/m/mqtt.json
+++ b/packages/m/mqtt.json
@@ -7,7 +7,7 @@
     "publish",
     "subscribe"
   ],
-  "author": "",
+  "author": "https://github.com/mqttjs/MQTT.js/graphs/contributors",
   "license": "MIT",
   "homepage": "https://github.com/mqttjs/MQTT.js#readme",
   "repository": {


### PR DESCRIPTION
Adding mqtt using npm auto-update from NPM package mqtt.

Resolves https://github.com/cdnjs/cdnjs/issues/13715.