### PR TITLE
Add acorn-loose w/ npm auto-update

### DIFF
--- a/packages/a/acorn-loose.json
+++ b/packages/a/acorn-loose.json
@@ -1,0 +1,22 @@
+{
+  "name": "acorn-loose",
+  "description": "Error-tolerant ECMAScript parser",
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "homepage": "https://github.com/acornjs/acorn",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/acornjs/acorn.git"
+  },
+  "npmName": "acorn-loose",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "*.js?(.map)"
+      ]
+    }
+  ],
+  "filename": "acorn-loose.js"
+}

--- a/packages/a/acorn-loose.json
+++ b/packages/a/acorn-loose.json
@@ -2,7 +2,7 @@
   "name": "acorn-loose",
   "description": "Error-tolerant ECMAScript parser",
   "keywords": [],
-  "author": "",
+  "author": "https://github.com/acornjs/acorn/graphs/contributors",
   "license": "MIT",
   "homepage": "https://github.com/acornjs/acorn",
   "repository": {


### PR DESCRIPTION
Adding acorn-loose using npm auto-update from NPM package acorn-loose.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13728.