### PR TITLE
Add acorn-walk w/ npm auto-update

### DIFF
--- a/packages/a/acorn-walk.json
+++ b/packages/a/acorn-walk.json
@@ -2,7 +2,7 @@
   "name": "acorn-walk",
   "description": "ECMAScript (ESTree) AST walker",
   "keywords": [],
-  "author": "",
+  "author": "https://github.com/acornjs/acorn/graphs/contributors",
   "license": "MIT",
   "homepage": "https://github.com/acornjs/acorn",
   "repository": {

--- a/packages/a/acorn-walk.json
+++ b/packages/a/acorn-walk.json
@@ -1,0 +1,22 @@
+{
+  "name": "acorn-walk",
+  "description": "ECMAScript (ESTree) AST walker",
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "homepage": "https://github.com/acornjs/acorn",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/acornjs/acorn.git"
+  },
+  "npmName": "acorn-walk",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "*.js?(.map)"
+      ]
+    }
+  ],
+  "filename": "walk.js"
+}


### PR DESCRIPTION
Adding acorn-walk using npm auto-update from NPM package acorn-walk.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13728.