### PR TITLE
Add ant-design-icons w/ npm auto-update

### DIFF
--- a/packages/a/ant-design-icons.json
+++ b/packages/a/ant-design-icons.json
@@ -1,0 +1,22 @@
+{
+  "name": "ant-design-icons",
+  "description": "<h1 align=\"center\"> Ant Design Icons for React </h1>",
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "homepage": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ant-design/ant-design-icons/tree/master/packages/icons-react"
+  },
+  "npmName": "@ant-design/icons",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "*.js"
+      ]
+    }
+  ],
+  "filename": "index.umd.min.js"
+}

--- a/packages/a/ant-design-icons.json
+++ b/packages/a/ant-design-icons.json
@@ -1,10 +1,18 @@
 {
   "name": "ant-design-icons",
-  "description": "<h1 align=\"center\"> Ant Design Icons for React </h1>",
-  "keywords": [],
-  "author": "",
+  "description": "Ant Design Icons for React",
+  "keywords": [
+    "angular",
+    "icons",
+    "svg-icons",
+    "react",
+    "vue",
+    "antd",
+    "ant-design"
+  ],
+  "author": "Ant Design Team",
   "license": "MIT",
-  "homepage": "",
+  "homepage": "https://ant.design/components/icon/",
   "repository": {
     "type": "git",
     "url": "https://github.com/ant-design/ant-design-icons/tree/master/packages/icons-react"


### PR DESCRIPTION
Adding ant-design-icons using npm auto-update from NPM package @ant-design/icons.

Resolves https://github.com/cdnjs/cdnjs/issues/13752.