### PR TITLE
Add embla-carousel w/ npm auto-update

### DIFF
--- a/packages/e/embla-carousel.json
+++ b/packages/e/embla-carousel.json
@@ -1,0 +1,29 @@
+{
+  "name": "embla-carousel",
+  "description": "Extensible bare bones carousels for the web",
+  "keywords": [
+    "slider",
+    "carousel",
+    "lightweight",
+    "touch"
+  ],
+  "author": {
+    "name": "David Cetinkaya"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/davidcetinkaya/embla-carousel#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/davidcetinkaya/embla-carousel.git"
+  },
+  "npmName": "embla-carousel",
+  "npmFileMap": [
+    {
+      "basePath": "lib",
+      "files": [
+        "**/*.@(js|ts)"
+      ]
+    }
+  ],
+  "filename": "index.js"
+}


### PR DESCRIPTION
Adding embla-carousel using npm auto-update from NPM package embla-carousel.

Resolves https://github.com/cdnjs/cdnjs/issues/13762.