### PR TITLE
Add bs-custom-file-input w/ npm auto-update

### DIFF
--- a/packages/b/bs-custom-file-input.json
+++ b/packages/b/bs-custom-file-input.json
@@ -1,0 +1,32 @@
+{
+  "name": "bs-custom-file-input",
+  "description": "A little plugin for Bootstrap 4 custom file input",
+  "keywords": [
+    "bootstrap",
+    "bootstrap 4",
+    "custom file input",
+    "vanillajs",
+    "react",
+    "angular"
+  ],
+  "author": {
+    "name": "Johann-S",
+    "email": "johann.servoire@gmail.com"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/Johann-S/bs-custom-file-input",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Johann-S/bs-custom-file-input.git"
+  },
+  "npmName": "bs-custom-file-input",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "*.@(js|map)"
+      ]
+    }
+  ],
+  "filename": "bs-custom-file-input.min.js"
+}


### PR DESCRIPTION
Adding bs-custom-file-input using npm auto-update from NPM package bs-custom-file-input.

Resolves https://github.com/cdnjs/cdnjs/issues/13784.