### PR TITLE
Add country-region-selector w/ npm auto-update

### DIFF
--- a/packages/c/country-region-selector.json
+++ b/packages/c/country-region-selector.json
@@ -1,0 +1,28 @@
+{
+  "name": "country-region-selector",
+  "description": "A simple, configurable JS library that add a country dropdown that automatically updates a corresponding region dropdown in your forms.",
+  "keywords": [
+    "countries",
+    "regions",
+    "dropdowns"
+  ],
+  "author": {
+    "name": "Ben Keen"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/benkeen/country-region-dropdowns#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/benkeen/country-region-dropdowns.git"
+  },
+  "npmName": "country-region-selector",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "*.js"
+      ]
+    }
+  ],
+  "filename": "crs.min.js"
+}


### PR DESCRIPTION
Adding country-region-selector using npm auto-update from NPM package country-region-selector.

Resolves https://github.com/cdnjs/cdnjs/issues/13794.