### PR TITLE
Add pdf-lib w/ npm auto-update

### DIFF
--- a/packages/p/pdf-lib.json
+++ b/packages/p/pdf-lib.json
@@ -1,0 +1,38 @@
+{
+  "name": "pdf-lib",
+  "description": "Create and modify PDF files with JavaScript",
+  "keywords": [
+    "pdf-lib",
+    "pdf",
+    "document",
+    "create",
+    "modify",
+    "creation",
+    "modification",
+    "edit",
+    "editing",
+    "typescript",
+    "javascript",
+    "library"
+  ],
+  "author": {
+    "name": "Andrew Dillon",
+    "email": "andrew.dillon.j@gmail.com"
+  },
+  "license": "MIT",
+  "homepage": "https://pdf-lib.js.org/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Hopding/pdf-lib.git"
+  },
+  "npmName": "pdf-lib",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "*.@(js|map)"
+      ]
+    }
+  ],
+  "filename": "pdf-lib.min.js"
+}


### PR DESCRIPTION
Adding pdf-lib using npm auto-update from NPM package pdf-lib.

Resolves https://github.com/cdnjs/cdnjs/issues/13950.