### PR TITLE
Add d3-graphviz w/ npm auto-update

### DIFF
--- a/packages/d/d3-graphviz.json
+++ b/packages/d/d3-graphviz.json
@@ -1,0 +1,31 @@
+{
+  "name": "d3-graphviz",
+  "description": "Graphviz DOT rendering and animated transitions for D3",
+  "keywords": [
+    "d3",
+    "d3-module",
+    "Graphviz",
+    "DOT",
+    "graph layout",
+    "animation",
+    "transition",
+    "Viz.js"
+  ],
+  "author": "",
+  "license": "BSD-3-Clause",
+  "homepage": "https://github.com/magjac/d3-graphviz",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/magjac/d3-graphviz.git"
+  },
+  "npmName": "d3-graphviz",
+  "npmFileMap": [
+    {
+      "basePath": "build",
+      "files": [
+        "*.@(js|map)"
+      ]
+    }
+  ],
+  "filename": "d3-graphviz.min.js"
+}

--- a/packages/d/d3-graphviz.json
+++ b/packages/d/d3-graphviz.json
@@ -11,7 +11,10 @@
     "transition",
     "Viz.js"
   ],
-  "author": "",
+  "author": {
+    "name": "Magnus Jacobsson",
+    "url": "https://github.com/magjac"
+  },
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/magjac/d3-graphviz",
   "repository": {


### PR DESCRIPTION
Adding d3-graphviz using npm auto-update from NPM package d3-graphviz.

Resolves https://github.com/cdnjs/cdnjs/issues/11275.