### PR TITLE
Add vue-echarts w/ npm auto-update

### DIFF
--- a/packages/v/vue-echarts.json
+++ b/packages/v/vue-echarts.json
@@ -1,0 +1,28 @@
+{
+  "name": "vue-echarts",
+  "description": "ECharts component for Vue.js.",
+  "keywords": [
+    "ECharts",
+    "Vue.js"
+  ],
+  "author": {
+    "name": "Justineo",
+    "url": "justice360@gmail.com"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/ecomfe/vue-echarts#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ecomfe/vue-echarts.git"
+  },
+  "npmName": "vue-echarts",
+  "npmFileMap": [
+    {
+      "basePath": "dist",
+      "files": [
+        "*.js"
+      ]
+    }
+  ],
+  "filename": "vue-echarts.js"
+}


### PR DESCRIPTION
Adding vue-echarts using npm auto-update from NPM package vue-echarts.

Resolves https://github.com/cdnjs/cdnjs/issues/13967.