### PR TITLE
Add datatables.net w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net.json
+++ b/packages/d/datatables.net.json
@@ -1,0 +1,35 @@
+{
+  "name": "datatables.net",
+  "description": "DataTables for jQuery ",
+  "keywords": [
+    "filter",
+    "sort",
+    "DataTables",
+    "jQuery",
+    "table",
+    "DataTables"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net",
+    "fileMap": [
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "jquery.dataTables.min.js"
+}


### PR DESCRIPTION
Adding datatables.net using npm auto-update from datatables.net.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.