### PR TITLE
Add datatables.net-bs w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-bs.json
+++ b/packages/d/datatables.net-bs.json
@@ -1,0 +1,41 @@
+{
+  "name": "datatables.net-bs",
+  "description": "DataTables for jQuery with styling for [Bootstrap 3](http://getbootstrap.com/)",
+  "keywords": [
+    "filter",
+    "sort",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-Bootstrap.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-bs",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "dataTables.bootstrap.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-bs using npm auto-update from datatables.net-bs.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.