### PR TITLE
Add datatables.net-bs4 w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-bs4.json
+++ b/packages/d/datatables.net-bs4.json
@@ -1,0 +1,38 @@
+{
+  "name": "datatables.net-bs4",
+  "description": "DataTables for jQuery with styling for [Bootstrap 4](http://getbootstrap.com/)",
+  "keywords": [
+    "filter",
+    "sort",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap 4"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {},
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-bs4",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "dataTables.bootstrap4.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-bs4 using npm auto-update from datatables.net-bs4.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.