### PR TITLE
Add datatables.net-buttons w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-buttons.json
+++ b/packages/d/datatables.net-buttons.json
@@ -1,0 +1,40 @@
+{
+  "name": "datatables.net-buttons",
+  "description": "Buttons for DataTables ",
+  "keywords": [
+    "buttons",
+    "excel",
+    "pdf",
+    "csv",
+    "column visibility",
+    "print",
+    "DataTables",
+    "jQuery",
+    "table",
+    "DataTables"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-Buttons.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-buttons",
+    "fileMap": [
+      {
+        "basePath": "",
+        "files": [
+          "js/*.js",
+          "swf/*.swf"
+        ]
+      }
+    ]
+  },
+  "filename": "js/dataTables.buttons.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-buttons using npm auto-update from datatables.net-buttons.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.