### PR TITLE
Add datatables.net-buttons-bs w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-buttons-bs.json
+++ b/packages/d/datatables.net-buttons-bs.json
@@ -1,0 +1,45 @@
+{
+  "name": "datatables.net-buttons-bs",
+  "description": "Buttons for DataTables with styling for [Bootstrap 3](http://getbootstrap.com/)",
+  "keywords": [
+    "buttons",
+    "excel",
+    "pdf",
+    "csv",
+    "column visibility",
+    "print",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-Buttons-Bootstrap.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-buttons-bs",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "buttons.bootstrap.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-buttons-bs using npm auto-update from datatables.net-buttons-bs.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.