### PR TITLE
Add datatables.net-colreorder w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-colreorder.json
+++ b/packages/d/datatables.net-colreorder.json
@@ -1,0 +1,34 @@
+{
+  "name": "datatables.net-colreorder",
+  "description": "ColReorder for DataTables ",
+  "keywords": [
+    "reorder",
+    "DataTables",
+    "jQuery",
+    "table",
+    "DataTables"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-ColReorder.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-colreorder",
+    "fileMap": [
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "dataTables.colReorder.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-colreorder using npm auto-update from datatables.net-colreorder.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.