### PR TITLE
Add datatables.net-colreorder-bs w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-colreorder-bs.json
+++ b/packages/d/datatables.net-colreorder-bs.json
@@ -1,0 +1,40 @@
+{
+  "name": "datatables.net-colreorder-bs",
+  "description": "ColReorder for DataTables with styling for [Bootstrap 3](http://getbootstrap.com/)",
+  "keywords": [
+    "reorder",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-ColReorder-Bootstrap.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-colreorder-bs",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "colReorder.bootstrap.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-colreorder-bs using npm auto-update from datatables.net-colreorder-bs.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.