### PR TITLE
Add datatables.net-buttons-bs4 w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-buttons-bs4.json
+++ b/packages/d/datatables.net-buttons-bs4.json
@@ -1,0 +1,42 @@
+{
+  "name": "datatables.net-buttons-bs4",
+  "description": "Buttons for DataTables with styling for [Bootstrap 4](http://getbootstrap.com/)",
+  "keywords": [
+    "buttons",
+    "excel",
+    "pdf",
+    "csv",
+    "column visibility",
+    "print",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap 4"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {},
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-buttons-bs4",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "buttons.bootstrap4.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-buttons-bs4 using npm auto-update from datatables.net-buttons-bs4.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.