### PR TITLE
Add datatables.net-fixedheader w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-fixedheader.json
+++ b/packages/d/datatables.net-fixedheader.json
@@ -1,0 +1,35 @@
+{
+  "name": "datatables.net-fixedheader",
+  "description": "FixedHeader for DataTables ",
+  "keywords": [
+    "fixed headers",
+    "sticky",
+    "DataTables",
+    "jQuery",
+    "table",
+    "DataTables"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-FixedHeader.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-fixedheader",
+    "fileMap": [
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "dataTables.fixedHeader.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-fixedheader using npm auto-update from datatables.net-fixedheader.