### PR TITLE
Add datatables.net-fixedcolumns w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-fixedcolumns.json
+++ b/packages/d/datatables.net-fixedcolumns.json
@@ -1,0 +1,34 @@
+{
+  "name": "datatables.net-fixedcolumns",
+  "description": "FixedColumns for DataTables ",
+  "keywords": [
+    "fixed columns",
+    "DataTables",
+    "jQuery",
+    "table",
+    "DataTables"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-FixedColumns.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-fixedcolumns",
+    "fileMap": [
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "dataTables.fixedColumns.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-fixedcolumns using npm auto-update from datatables.net-fixedcolumns.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.