### PR TITLE
Add datatables.net-rowgroup w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-rowgroup.json
+++ b/packages/d/datatables.net-rowgroup.json
@@ -1,0 +1,31 @@
+{
+  "name": "datatables.net-rowgroup",
+  "description": "RowGroup for DataTables ",
+  "keywords": [
+    "row grouping",
+    "DataTables",
+    "jQuery",
+    "table",
+    "DataTables"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {},
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-rowgroup",
+    "fileMap": [
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "dataTables.rowGroup.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-rowgroup using npm auto-update from datatables.net-rowgroup.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.