### PR TITLE
Add datatables.net-scroller w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-scroller.json
+++ b/packages/d/datatables.net-scroller.json
@@ -1,0 +1,34 @@
+{
+  "name": "datatables.net-scroller",
+  "description": "Scroller for DataTables ",
+  "keywords": [
+    "virtual scrolling",
+    "DataTables",
+    "jQuery",
+    "table",
+    "DataTables"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-Scroller.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-scroller",
+    "fileMap": [
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "dataTables.scroller.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-scroller using npm auto-update from datatables.net-scroller.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.