### PR TITLE
Add datatables.net-keytable w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-keytable.json
+++ b/packages/d/datatables.net-keytable.json
@@ -1,0 +1,36 @@
+{
+  "name": "datatables.net-keytable",
+  "description": "KeyTable for DataTables ",
+  "keywords": [
+    "spreadsheet",
+    "excel",
+    "keyboard",
+    "DataTables",
+    "jQuery",
+    "table",
+    "DataTables"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-KeyTable.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-keytable",
+    "fileMap": [
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "dataTables.keyTable.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-keytable using npm auto-update from datatables.net-keytable.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.