### PR TITLE
Add datatables.net-colreorder-dt w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-colreorder-dt.json
+++ b/packages/d/datatables.net-colreorder-dt.json
@@ -1,0 +1,40 @@
+{
+  "name": "datatables.net-colreorder-dt",
+  "description": "ColReorder for DataTables ",
+  "keywords": [
+    "reorder",
+    "DataTables",
+    "jQuery",
+    "table",
+    "DataTables"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-ColReorder-DataTables.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-colreorder-dt",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "colReorder.dataTables.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-colreorder-dt using npm auto-update from datatables.net-colreorder-dt.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.