### PR TITLE
Add datatables.net-rowreorder w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-rowreorder.json
+++ b/packages/d/datatables.net-rowreorder.json
@@ -1,0 +1,34 @@
+{
+  "name": "datatables.net-rowreorder",
+  "description": "RowReorder for DataTables ",
+  "keywords": [
+    "row reordering",
+    "DataTables",
+    "jQuery",
+    "table",
+    "DataTables"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-RowReorder.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-rowreorder",
+    "fileMap": [
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "dataTables.rowReorder.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-rowreorder using npm auto-update from datatables.net-rowreorder.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.