### PR TITLE
Add datatables.net-buttons-dt w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-buttons-dt.json
+++ b/packages/d/datatables.net-buttons-dt.json
@@ -1,0 +1,45 @@
+{
+  "name": "datatables.net-buttons-dt",
+  "description": "Buttons for DataTables ",
+  "keywords": [
+    "buttons",
+    "excel",
+    "pdf",
+    "csv",
+    "column visibility",
+    "print",
+    "DataTables",
+    "jQuery",
+    "table",
+    "DataTables"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-Buttons-DataTables.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-buttons-dt",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "buttons.dataTables.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-buttons-dt using npm auto-update from datatables.net-buttons-dt.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.