### PR TITLE
Add datatables.net-autofill w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-autofill.json
+++ b/packages/d/datatables.net-autofill.json
@@ -1,0 +1,35 @@
+{
+  "name": "datatables.net-autofill",
+  "description": "AutoFill for DataTables ",
+  "keywords": [
+    "autofill",
+    "excel",
+    "DataTables",
+    "jQuery",
+    "table",
+    "DataTables"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-AutoFill.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-autofill",
+    "fileMap": [
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "dataTables.autoFill.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-autofill using npm auto-update from datatables.net-autofill.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.