### PR TITLE
Add datatables.net-keytable-bs4 w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-keytable-bs4.json
+++ b/packages/d/datatables.net-keytable-bs4.json
@@ -1,0 +1,39 @@
+{
+  "name": "datatables.net-keytable-bs4",
+  "description": "KeyTable for DataTables with styling for [Bootstrap 4](http://getbootstrap.com/)",
+  "keywords": [
+    "spreadsheet",
+    "excel",
+    "keyboard",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap 4"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {},
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-keytable-bs4",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "keyTable.bootstrap4.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-keytable-bs4 using npm auto-update from datatables.net-keytable-bs4.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.