### PR TITLE
Add datatables.net-select-dt w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-select-dt.json
+++ b/packages/d/datatables.net-select-dt.json
@@ -1,0 +1,41 @@
+{
+  "name": "datatables.net-select-dt",
+  "description": "Select for DataTables ",
+  "keywords": [
+    "select",
+    "selection",
+    "DataTables",
+    "jQuery",
+    "table",
+    "DataTables"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-Select-DataTables.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-select-dt",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "select.dataTables.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-select-dt using npm auto-update from datatables.net-select-dt.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.