### PR TITLE
Add datatables.net-responsive-dt w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-responsive-dt.json
+++ b/packages/d/datatables.net-responsive-dt.json
@@ -1,0 +1,40 @@
+{
+  "name": "datatables.net-responsive-dt",
+  "description": "Responsive for DataTables ",
+  "keywords": [
+    "responsive",
+    "DataTables",
+    "jQuery",
+    "table",
+    "DataTables"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-Responsive-DataTables.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-responsive-dt",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "responsive.dataTables.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-responsive-dt using npm auto-update from datatables.net-responsive-dt.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.