### PR TITLE
Add datatables.net-select-bs w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-select-bs.json
+++ b/packages/d/datatables.net-select-bs.json
@@ -1,0 +1,41 @@
+{
+  "name": "datatables.net-select-bs",
+  "description": "Select for DataTables with styling for [Bootstrap 3](http://getbootstrap.com/)",
+  "keywords": [
+    "select",
+    "selection",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-Select-Bootstrap.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-select-bs",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "select.bootstrap.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-select-bs using npm auto-update from datatables.net-select-bs.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.