### PR TITLE
Add datatables.net-zf w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-zf.json
+++ b/packages/d/datatables.net-zf.json
@@ -1,0 +1,37 @@
+{
+  "name": "datatables.net-zf",
+  "description": "DataTables for jQuery with styling for [Zurb Foundation](http://foundation.zurb.com/)",
+  "keywords": [
+    "filter",
+    "sort",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Foundation"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-Foundation.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-zf",
+    "fileMap": [
+      {
+        "basePath": "",
+        "files": [
+          "css/*.css",
+          "images/*.png",
+          "js/*js"
+        ]
+      }
+    ]
+  },
+  "filename": "js/dataTables.foundation.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-zf using npm auto-update from datatables.net-zf.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.