### PR TITLE
Add datatables.net-se w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-se.json
+++ b/packages/d/datatables.net-se.json
@@ -1,0 +1,41 @@
+{
+  "name": "datatables.net-se",
+  "description": "DataTables for jQuery with styling for [Semantic UI](http://semantic-ui.com/)",
+  "keywords": [
+    "filter",
+    "sort",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Semantic UI"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-SemanticUI.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-se",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "dataTables.semanticui.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-se using npm auto-update from datatables.net-se.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.