### PR TITLE
Add datatables.net-fixedheader-dt w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-fixedheader-dt.json
+++ b/packages/d/datatables.net-fixedheader-dt.json
@@ -1,0 +1,41 @@
+{
+  "name": "datatables.net-fixedheader-dt",
+  "description": "FixedHeader for DataTables ",
+  "keywords": [
+    "fixed headers",
+    "sticky",
+    "DataTables",
+    "jQuery",
+    "table",
+    "DataTables"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-FixedHeader-DataTables.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-fixedheader-dt",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "fixedHeader.dataTables.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-fixedheader-dt using npm auto-update from datatables.net-fixedheader-dt.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.