### PR TITLE
Add datatables.net-rowreorder-bs w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-rowreorder-bs.json
+++ b/packages/d/datatables.net-rowreorder-bs.json
@@ -1,0 +1,40 @@
+{
+  "name": "datatables.net-rowreorder-bs",
+  "description": "RowReorder for DataTables with styling for [Bootstrap 3](http://getbootstrap.com/)",
+  "keywords": [
+    "row reordering",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-RowReorder-Bootstrap.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-rowreorder-bs",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "rowReorder.bootstrap.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-rowreorder-bs using npm auto-update from datatables.net-rowreorder-bs.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.