### PR TITLE
Add datatables.net-searchpanes w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-searchpanes.json
+++ b/packages/d/datatables.net-searchpanes.json
@@ -1,0 +1,35 @@
+{
+  "name": "datatables.net-searchpanes",
+  "description": "SearchPanes for DataTables ",
+  "keywords": [
+    "Search",
+    "Filtering",
+    "DataTables",
+    "jQuery",
+    "table",
+    "DataTables"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-SearchPanes.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-searchpanes",
+    "fileMap": [
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "dataTables.searchPanes.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-searchpanes using npm auto-update from datatables.net-searchpanes.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.