### PR TITLE
Add datatables.net-fixedheader-bs w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-fixedheader-bs.json
+++ b/packages/d/datatables.net-fixedheader-bs.json
@@ -1,0 +1,41 @@
+{
+  "name": "datatables.net-fixedheader-bs",
+  "description": "FixedHeader for DataTables with styling for [Bootstrap 3](http://getbootstrap.com/)",
+  "keywords": [
+    "fixed headers",
+    "sticky",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-FixedHeader-Bootstrap.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-fixedheader-bs",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "fixedHeader.bootstrap.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-fixedheader-bs using npm auto-update from datatables.net-fixedheader-bs.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.