### PR TITLE
Add datatables.net-fixedcolumns-bs w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-fixedcolumns-bs.json
+++ b/packages/d/datatables.net-fixedcolumns-bs.json
@@ -1,0 +1,40 @@
+{
+  "name": "datatables.net-fixedcolumns-bs",
+  "description": "FixedColumns for DataTables with styling for [Bootstrap 3](http://getbootstrap.com/)",
+  "keywords": [
+    "fixed columns",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-FixedColumns-Bootstrap.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-fixedcolumns-bs",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "fixedColumns.bootstrap.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-fixedcolumns-bs using npm auto-update from datatables.net-fixedcolumns-bs.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.