### PR TITLE
Add datatables.net-scroller-dt w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-scroller-dt.json
+++ b/packages/d/datatables.net-scroller-dt.json
@@ -1,0 +1,40 @@
+{
+  "name": "datatables.net-scroller-dt",
+  "description": "Scroller for DataTables ",
+  "keywords": [
+    "virtual scrolling",
+    "DataTables",
+    "jQuery",
+    "table",
+    "DataTables"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-Scroller-DataTables.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-scroller-dt",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "scroller.dataTables.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-scroller-dt using npm auto-update from datatables.net-scroller-dt.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.