### PR TITLE
Add datatables.net-rowgroup-dt w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-rowgroup-dt.json
+++ b/packages/d/datatables.net-rowgroup-dt.json
@@ -1,0 +1,37 @@
+{
+  "name": "datatables.net-rowgroup-dt",
+  "description": "RowGroup for DataTables ",
+  "keywords": [
+    "row grouping",
+    "DataTables",
+    "jQuery",
+    "table",
+    "DataTables"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {},
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-rowgroup-dt",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "rowGroup.dataTables.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-rowgroup-dt using npm auto-update from datatables.net-rowgroup-dt.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.