### PR TITLE
Add datatables.net-rowgroup-bs w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-rowgroup-bs.json
+++ b/packages/d/datatables.net-rowgroup-bs.json
@@ -1,0 +1,37 @@
+{
+  "name": "datatables.net-rowgroup-bs",
+  "description": "RowGroup for DataTables with styling for [Bootstrap 3](http://getbootstrap.com/)",
+  "keywords": [
+    "row grouping",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {},
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-rowgroup-bs",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "rowGroup.bootstrap.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-rowgroup-bs using npm auto-update from datatables.net-rowgroup-bs.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.