### PR TITLE
Add datatables.net-fixedcolumns-dt w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-fixedcolumns-dt.json
+++ b/packages/d/datatables.net-fixedcolumns-dt.json
@@ -1,0 +1,40 @@
+{
+  "name": "datatables.net-fixedcolumns-dt",
+  "description": "FixedColumns for DataTables ",
+  "keywords": [
+    "fixed columns",
+    "DataTables",
+    "jQuery",
+    "table",
+    "DataTables"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-FixedColumns-DataTables.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-fixedcolumns-dt",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "fixedColumns.dataTables.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-fixedcolumns-dt using npm auto-update from datatables.net-fixedcolumns-dt.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.