### PR TITLE
Add datatables.net-keytable-bs w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-keytable-bs.json
+++ b/packages/d/datatables.net-keytable-bs.json
@@ -1,0 +1,42 @@
+{
+  "name": "datatables.net-keytable-bs",
+  "description": "KeyTable for DataTables with styling for [Bootstrap 3](http://getbootstrap.com/)",
+  "keywords": [
+    "spreadsheet",
+    "excel",
+    "keyboard",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-KeyTable-Bootstrap.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-keytable-bs",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "keyTable.bootstrap.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-keytable-bs using npm auto-update from datatables.net-keytable-bs.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.