### PR TITLE
Add datatables.net-editor w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-editor.json
+++ b/packages/d/datatables.net-editor.json
@@ -1,0 +1,30 @@
+{
+  "name": "datatables.net-editor",
+  "description": "DataTables Editor",
+  "keywords": [
+    "DataTables",
+    "Editor"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd"
+  },
+  "license": "SEE LICENSE IN License.md",
+  "homepage": "",
+  "repository": {
+    "type": "git",
+    "url": "github.com:DataTables/editor-npm.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-editor",
+    "fileMap": [
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "dataTables.editor.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-editor using npm auto-update from datatables.net-editor.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.