### PR TITLE
Add datatables.net-autofill-bs w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-autofill-bs.json
+++ b/packages/d/datatables.net-autofill-bs.json
@@ -1,0 +1,38 @@
+{
+  "name": "datatables.net-autofill-bs",
+  "description": "AutoFill for DataTables with styling for [Bootstrap](http://getbootstrap.com/)",
+  "keywords": [
+    "autofill",
+    "excel",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {},
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-autofill-bs",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "autoFill.bootstrap.js"
+}


### PR DESCRIPTION
Adding datatables.net-autofill-bs using npm auto-update from datatables.net-autofill-bs.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.