### PR TITLE
Add datatables.net-scroller-jqui w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-scroller-jqui.json
+++ b/packages/d/datatables.net-scroller-jqui.json
@@ -1,0 +1,40 @@
+{
+  "name": "datatables.net-scroller-jqui",
+  "description": "Scroller for DataTables with styling for [jQuery UI](http://jqueryui.com/)",
+  "keywords": [
+    "virtual scrolling",
+    "DataTables",
+    "jQuery",
+    "table",
+    "jQuery UI"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-Scroller-jQueryUI.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-scroller-jqui",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "scroller.jqueryui.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-scroller-jqui using npm auto-update from datatables.net-scroller-jqui.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.