### PR TITLE
Add datatables.net-scroller-bs w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-scroller-bs.json
+++ b/packages/d/datatables.net-scroller-bs.json
@@ -1,0 +1,40 @@
+{
+  "name": "datatables.net-scroller-bs",
+  "description": "Scroller for DataTables with styling for [Bootstrap 3](http://getbootstrap.com/)",
+  "keywords": [
+    "virtual scrolling",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-Scroller-Bootstrap.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-scroller-bs",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "scroller.bootstrap.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-scroller-bs using npm auto-update from datatables.net-scroller-bs.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.