### PR TITLE
Add datatables.net-editor-bs4 w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-editor-bs4.json
+++ b/packages/d/datatables.net-editor-bs4.json
@@ -1,0 +1,37 @@
+{
+  "name": "datatables.net-editor-bs4",
+  "description": "DataTables Editor - Bootstrap 4 integration",
+  "keywords": [
+    "DataTables",
+    "Editor",
+    "Bootstrap"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd"
+  },
+  "license": "SEE LICENSE IN License.md",
+  "homepage": "",
+  "repository": {
+    "type": "git",
+    "url": "github.com:DataTables/editor-npm-bs.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-editor-bs4",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "editor.bootstrap4.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-editor-bs4 using npm auto-update from datatables.net-editor-bs4.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.