### PR TITLE
Add datatables.net-buttons-zf w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-buttons-zf.json
+++ b/packages/d/datatables.net-buttons-zf.json
@@ -1,0 +1,45 @@
+{
+  "name": "datatables.net-buttons-zf",
+  "description": "Buttons for DataTables with styling for [Zurb Foundation](http://foundation.zurb.com/)",
+  "keywords": [
+    "buttons",
+    "excel",
+    "pdf",
+    "csv",
+    "column visibility",
+    "print",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Foundation"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-Buttons-Foundation.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-buttons-zf",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "buttons.foundation.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-buttons-zf using npm auto-update from datatables.net-buttons-zf.