### PR TITLE
Add datatables.net-responsive-zf w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-responsive-zf.json
+++ b/packages/d/datatables.net-responsive-zf.json
@@ -1,0 +1,40 @@
+{
+  "name": "datatables.net-responsive-zf",
+  "description": "Responsive for DataTables with styling for [Zurb Foundation](http://foundation.zurb.com/)",
+  "keywords": [
+    "responsive",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Foundation"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-Responsive-Foundation.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-responsive-zf",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "responsive.foundation.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-responsive-zf using npm auto-update from datatables.net-responsive-zf.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.