### PR TITLE
Add datatables.net-buttons-se w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-buttons-se.json
+++ b/packages/d/datatables.net-buttons-se.json
@@ -1,0 +1,42 @@
+{
+  "name": "datatables.net-buttons-se",
+  "description": "Buttons for DataTables with styling for [Semantic UI](http://semantic-ui.com/)",
+  "keywords": [
+    "buttons",
+    "excel",
+    "pdf",
+    "csv",
+    "column visibility",
+    "print",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Semantic UI"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {},
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-buttons-se",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "buttons.semanticui.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-buttons-se using npm auto-update from datatables.net-buttons-se.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.