### PR TITLE
Add datatables.net-rowreorder-dt w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-rowreorder-dt.json
+++ b/packages/d/datatables.net-rowreorder-dt.json
@@ -1,0 +1,40 @@
+{
+  "name": "datatables.net-rowreorder-dt",
+  "description": "RowReorder for DataTables ",
+  "keywords": [
+    "row reordering",
+    "DataTables",
+    "jQuery",
+    "table",
+    "DataTables"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-RowReorder-DataTables.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-rowreorder-dt",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "rowReorder.dataTables.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-rowreorder-dt using npm auto-update from datatables.net-rowreorder-dt.

Resolves  N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.