### PR TITLE
Add datatables.net-searchpanes-bs4 w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-searchpanes-bs4.json
+++ b/packages/d/datatables.net-searchpanes-bs4.json
@@ -1,0 +1,41 @@
+{
+  "name": "datatables.net-searchpanes-bs4",
+  "description": "SearchPanes for DataTables with styling for [Bootstrap](http://getbootstrap.com/)",
+  "keywords": [
+    "Search",
+    "Filter",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-SearchPanes-Bootstrap4.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-searchpanes-bs4",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "searchPanes.bootstrap4.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-searchpanes-bs4 using npm auto-update from datatables.net-searchpanes-bs4.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.