### PR TITLE
Add datatables.net-responsive-se w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-responsive-se.json
+++ b/packages/d/datatables.net-responsive-se.json
@@ -1,0 +1,37 @@
+{
+  "name": "datatables.net-responsive-se",
+  "description": "Responsive for DataTables with styling for [Semantic UI](http://semantic-ui.com/)",
+  "keywords": [
+    "responsive",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Semantic UI"
+  ],
+  "author": {
+    "name": "SpryMedia Ltd",
+    "url": "http://datatables.net"
+  },
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {},
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-responsive-se",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "responsive.semanticui.min.js"
+}


### PR DESCRIPTION
Adding datatables.net-responsive-se using npm auto-update from datatables.net-responsive-se.

Resolves N/A. cc https://github.com/cdnjs/cdnjs/issues/13978.