### PR TITLE
Update vuetify w/ npm auto-update

### DIFF
--- a/packages/v/vuetify.json
+++ b/packages/v/vuetify.json
@@ -1,7 +1,6 @@
 {
   "name": "vuetify",
   "filename": "vuetify.min.js",
-  "version": "2.2.19",
   "description": "Vue.js 2 Semantic Component Framework",
   "author": {
     "email": "john.j.leider@gmail.com",
@@ -24,7 +23,7 @@
     {
       "basePath": "dist",
       "files": [
-        "**/!(*.json)"
+        "**/*"
       ]
     }
   ]


### PR DESCRIPTION
cc https://cdnjs.discourse.group/t/vuetify-js-not-updated-correctly/395

I see no reason for us to be excluding JSON files here -- I hope that this change may also push the bot to pull in the latest release, [`2.3.0`](https://www.npmjs.com/package/vuetify#versions).