### PR TITLE
Update startbootstrap-sb-admin-2 w/ git auto-update

### DIFF
--- a/packages/s/startbootstrap-sb-admin-2.json
+++ b/packages/s/startbootstrap-sb-admin-2.json
@@ -13,7 +13,7 @@
     "target": "git://github.com/BlackrockDigital/startbootstrap-sb-admin-2.git",
     "fileMap": [
       {
-        "basePath": "dist",
+        "basePath": ".",
         "files": [
           "js/sb-admin-2.js",
           "js/sb-admin-2.min.js",

--- a/packages/s/startbootstrap-sb-admin-2.json
+++ b/packages/s/startbootstrap-sb-admin-2.json
@@ -1,7 +1,6 @@
 {
   "name": "startbootstrap-sb-admin-2",
   "filename": "js/sb-admin-2.min.js",
-  "version": "3.3.7+1",
   "homepage": "https://startbootstrap.com/template-overviews/sb-admin-2/",
   "description": "A free, open source, Bootstrap admin theme created by Start Bootstrap",
   "keywords": [

--- a/packages/s/startbootstrap-sb-admin-2.json
+++ b/packages/s/startbootstrap-sb-admin-2.json
@@ -13,7 +13,7 @@
     "target": "git://github.com/BlackrockDigital/startbootstrap-sb-admin-2.git",
     "fileMap": [
       {
-        "basePath": ".",
+        "basePath": "",
         "files": [
           "js/sb-admin-2.js",
           "js/sb-admin-2.min.js",


### PR DESCRIPTION
The site's version is apparently stuck at 3.3.7+1 as shown in the screen shot attached. After checking I figure that it was due to the specific version being pinned, so I remove `version` in hopes that the cdn will update the template.

First time here.. sorry for any mistakes made.

Screenshot:
![image](https://user-images.githubusercontent.com/31540342/85096004-a0d3f180-b225-11ea-8643-6361e243f5c1.png)
