### PR TITLE
Update css-social-buttons w/ git auto-update

### DIFF
--- a/packages/c/css-social-buttons.json
+++ b/packages/c/css-social-buttons.json
@@ -1,7 +1,6 @@
 {
   "name": "css-social-buttons",
   "description": "Zocial CSS social buttons.",
-  "version": "",
   "keywords": ["css", "font", "icon", "social", "zocial"],
   "homepage": "http://zocial.smcllns.com/",
   "filename": "css/zocial.min.css",

--- a/packages/c/css-social-buttons.json
+++ b/packages/c/css-social-buttons.json
@@ -1,7 +1,7 @@
 {
   "name": "css-social-buttons",
   "description": "Zocial CSS social buttons.",
-  "version": "1.3.0",
+  "version": "",
   "keywords": ["css", "font", "icon", "social", "zocial"],
   "homepage": "http://zocial.smcllns.com/",
   "filename": "css/zocial.min.css",

--- a/packages/c/css-social-buttons.json
+++ b/packages/c/css-social-buttons.json
@@ -2,13 +2,7 @@
   "name": "css-social-buttons",
   "description": "Zocial CSS social buttons.",
   "version": "1.3.0",
-  "keywords": [
-    "css",
-    "font",
-    "icon",
-    "social",
-    "zocial"
-  ],
+  "keywords": ["css", "font", "icon", "social", "zocial"],
   "homepage": "http://zocial.smcllns.com/",
   "filename": "css/zocial.min.css",
   "repository": {
@@ -22,9 +16,7 @@
     "fileMap": [
       {
         "basePath": "",
-        "files": [
-          "css/zocial*"
-        ]
+        "files": ["css/zocial*", "src/*.svg"]
       }
     ]
   },

--- a/packages/c/css-social-buttons.json
+++ b/packages/c/css-social-buttons.json
@@ -1,7 +1,13 @@
 {
   "name": "css-social-buttons",
   "description": "Zocial CSS social buttons.",
-  "keywords": ["css", "font", "icon", "social", "zocial"],
+  "keywords": [
+    "css",
+    "font",
+    "icon",
+    "social",
+    "zocial"
+  ],
   "homepage": "http://zocial.smcllns.com/",
   "filename": "css/zocial.min.css",
   "repository": {
@@ -15,7 +21,10 @@
     "fileMap": [
       {
         "basePath": "",
-        "files": ["css/zocial*", "src/*.svg"]
+        "files": [
+          "css/zocial*",
+          "src/*.svg"
+        ]
       }
     ]
   },


### PR DESCRIPTION
This package is a css library for social icons and social login buttons.

Currently the css and font file for the images are hosted on cdnjs. This change makes each individual icon available on cdnjs too, as the font file is becoming heavy from so many icons and most users only need one or two icons for their site. This way they request just individual smaller icons.