### PR TITLE
Update rambda w/ npm auto-update

### DIFF
--- a/packages/r/rambda.json
+++ b/packages/r/rambda.json
@@ -1,8 +1,8 @@
 {
   "name": "rambda",
-  "filename": "webVersion.js",
-  "version": "1.2.2",
+  "filename": "rambda.umd.js",
   "description": "Lightweight alternative to Ramda",
+  "homepage": "https://selfrefactor.github.io/rambda",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/selfrefactor/rambda.git"
@@ -18,13 +18,16 @@
     "url": "https://github.com/selfrefactor"
   },
   "license": "MIT",
-  "npmName": "rambda",
-  "npmFileMap": [
-    {
-      "basePath": "",
-      "files": [
-        "webVersion.js"
-      ]
-    }
-  ]
+  "autoupdate": {
+    "source": "npm",
+    "target": "rambda",
+    "fileMap": [
+      {
+        "basePath": "dist",
+        "files": [
+          "*.js?(.map)"
+        ]
+      }
+    ]
+  }
 }

--- a/packages/r/rambda.json
+++ b/packages/r/rambda.json
@@ -25,7 +25,7 @@
       {
         "basePath": "dist",
         "files": [
-          "*.js?(.map)"
+          "*.js"
         ]
       }
     ]


### PR DESCRIPTION
Rambda is outdated, the npm package no longer has a minified `webVersion.js` bundle.

It has slightly broken the web app, since it thinks the latest version is one that hasn't got a corresponding folder.