### PR TITLE
Add rambdax w/ npm auto-update

### DIFF
--- a/packages/r/rambdax.json
+++ b/packages/r/rambdax.json
@@ -14,7 +14,7 @@
     "util"
   ],
   "author": {
-    "name": "self_refactor",
+    "name": "Dejan Toteff",
     "url": "https://github.com/selfrefactor"
   },
   "license": "MIT",

--- a/packages/r/rambdax.json
+++ b/packages/r/rambdax.json
@@ -1,0 +1,33 @@
+{
+  "name": "rambdax",
+  "filename": "rambdax.umd.js",
+  "description": "Lightweight alternative to Ramda - extended version",
+  "homepage": "https://selfrefactor.github.io/rambdax",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/selfrefactor/rambdax.git"
+  },
+  "keywords": [
+    "rambda",
+    "lodash",
+    "ramda",
+    "util"
+  ],
+  "author": {
+    "name": "self_refactor",
+    "url": "https://github.com/selfrefactor"
+  },
+  "license": "MIT",
+  "autoupdate": {
+    "source": "npm",
+    "target": "rambdax",
+    "fileMap": [
+      {
+        "basePath": "dist",
+        "files": [
+          "*.js?(.map)"
+        ]
+      }
+    ]
+  }
+}

--- a/packages/r/rambdax.json
+++ b/packages/r/rambdax.json
@@ -25,7 +25,7 @@
       {
         "basePath": "dist",
         "files": [
-          "*.js?(.map)"
+          "*.js"
         ]
       }
     ]


### PR DESCRIPTION
This is the extended version of Rambda. It has thousands of weekly downloads <https://www.npmjs.com/package/rambdax>, though the stars are a quite a bit lower than Rambda.

I'm not a maintainer, if that in any way helps the case for adding this package.