### PR TITLE
Add normalize-opentype.css w/ npm auto-update

### DIFF
--- a/packages/n/normalize-opentype.css.json
+++ b/packages/n/normalize-opentype.css.json
@@ -1,0 +1,36 @@
+{
+  "name": "normalize-opentype.css",
+  "description": "Adds OpenType features—ligatures, kerning, and more—to Normalize.css.",
+  "keywords": [
+    "normalize",
+    "type",
+    "typography",
+    "opentype",
+    "fonts",
+    "css"
+  ],
+  "author": {
+    "name": "Kenneth Ormandy",
+    "email": "hello@kennethormandy.com"
+  },
+  "license": "MIT",
+  "homepage": "http://kennethormandy.com/journal/normalize-opentype-css",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:kennethormandy/normalize-opentype.css.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "normalize-opentype.css",
+    "fileMap": [
+      {
+        "basePath": "",
+        "files": [
+          "*.@(css|scss)",
+          "assets/*.@(png|svg)"
+        ]
+      }
+    ]
+  },
+  "filename": "normalize-opentype.css"
+}


### PR DESCRIPTION
Adding normalize-opentype.css using npm auto-update from normalize-opentype.css.

Resolves #289.