### PR TITLE
Remove airbrake-js git auto-update config

### DIFF
--- a/packages/a/airbrake-js.json
+++ b/packages/a/airbrake-js.json
@@ -15,17 +15,5 @@
   "author": "Airbrake",
   "license": "MIT",
   "homepage": "https://airbrake.io",
-  "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/airbrake/airbrake-js.git",
-    "fileMap": [
-      {
-        "basePath": "dist",
-        "files": [
-          "client.*"
-        ]
-      }
-    ]
-  },
   "filename": "client.min.js"
 }


### PR DESCRIPTION
The auto-update config is out-of-date and the "version counter" has been
reset[1]. We can't overwrite existing versions, so we have no other
options.

[1] https://github.com/airbrake/airbrake-js/issues/602#issuecomment-545057436

Refs #302