### PR TITLE
Update clmtrackr w/ git auto-update

### DIFF
--- a/packages/c/clmtrackr.json
+++ b/packages/c/clmtrackr.json
@@ -14,11 +14,11 @@
     "url": "https://github.com/auduno/clmtrackr.git"
   },
   "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/auduno/clmtrackr.git",
+    "source": "npm",
+    "target": "clmtrackr",
     "fileMap": [
       {
-        "basePath": "",
+        "basePath": "build",
         "files": [
           "clmtrackr*"
         ]

--- a/packages/c/clmtrackr.json
+++ b/packages/c/clmtrackr.json
@@ -14,8 +14,8 @@
     "url": "https://github.com/auduno/clmtrackr.git"
   },
   "autoupdate": {
-    "source": "npm",
-    "target": "clmtrackr",
+    "source": "git",
+    "target": "git://github.com/auduno/clmtrackr.git",
     "fileMap": [
       {
         "basePath": "build",


### PR DESCRIPTION
The auto-update glob is out-of-date, so let's switch to NPM and fix the
glob.

Refs #302