### PR TITLE
Update spin.js w/ npm auto-update

### DIFF
--- a/packages/s/spin.js.json
+++ b/packages/s/spin.js.json
@@ -19,8 +19,7 @@
       {
         "basePath": "",
         "files": [
-          "spin.js",
-          "spin.css"
+          "*.@(js|css|ts)"
         ]
       }
     ]

--- a/packages/s/spin.js.json
+++ b/packages/s/spin.js.json
@@ -13,14 +13,14 @@
     "url": "git://github.com/fgnass/spin.js.git"
   },
   "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/fgnass/spin.js.git",
+    "source": "npm",
+    "target": "spin.js",
     "fileMap": [
       {
         "basePath": "",
         "files": [
           "spin.js",
-          "spin.min.js"
+          "spin.css"
         ]
       }
     ]


### PR DESCRIPTION
The auto-update glob is out-of-date, so let's switch to NPM and fix the
glob.

Refs #302

---
This was done by-hand with help from `curl -s $(npm view X dist.tarball) | tar -tvzf -`