### PR TITLE
Remove teadao npm auto-update config

### DIFF
--- a/packages/t/teadao.json
+++ b/packages/t/teadao.json
@@ -14,17 +14,5 @@
     "teapao"
   ],
   "author": "Billgo",
-  "homepage": "https://www.teasim.com/",
-  "autoupdate": {
-    "source": "npm",
-    "target": "teadao",
-    "fileMap": [
-      {
-        "basePath": "library",
-        "files": [
-          "teadao*"
-        ]
-      }
-    ]
-  }
+  "homepage": "https://www.teasim.com/"
 }


### PR DESCRIPTION
The NPM package is deprecated and 1.0.0 just contains a empty index.js,
a package.json and a README.md file.

[1] https://www.npmjs.com/package/teadao

Refs #302