### PR TITLE
Update reveal.js w/ git auto-update

### DIFF
--- a/packages/r/reveal.js.json
+++ b/packages/r/reveal.js.json
@@ -1,6 +1,6 @@
 {
   "name": "reveal.js",
-  "filename": "dist/reveal.js",
+  "filename": "reveal.js",
   "description": "The HTML Presentation Framework",
   "homepage": "https://revealjs.com/",
   "keywords": [

--- a/packages/r/reveal.js.json
+++ b/packages/r/reveal.js.json
@@ -11,7 +11,7 @@
   ],
   "autoupdate": {
     "source": "git",
-    "target": "git://github.com/hakimel/reveal.js.git",
+    "target": "https://github.com/hakimel/reveal.js.git",
     "fileMap": [
       {
         "basePath": "dist",

--- a/packages/r/reveal.js.json
+++ b/packages/r/reveal.js.json
@@ -1,8 +1,8 @@
 {
   "name": "reveal.js",
-  "filename": "js/reveal.min.js",
+  "filename": "dist/reveal.js",
   "description": "The HTML Presentation Framework",
-  "homepage": "http://lab.hakim.se/reveal-js/",
+  "homepage": "https://revealjs.com/",
   "keywords": [
     "reveal.js",
     "reveal",
@@ -16,14 +16,8 @@
       {
         "basePath": "",
         "files": [
-          "css/**/*.css",
-          "js/*.js",
-          "lib/**/*.js",
-          "lib/**/*.css",
-          "lib/**/*.eot",
-          "lib/**/*.ttf",
-          "lib/**/*.woff",
-          "plugin/**/*.js"
+          "dist/**",
+          "plugin/**"
         ]
       }
     ]

--- a/packages/r/reveal.js.json
+++ b/packages/r/reveal.js.json
@@ -14,9 +14,14 @@
     "target": "git://github.com/hakimel/reveal.js.git",
     "fileMap": [
       {
+        "basePath": "dist",
+        "files": [
+          "**/*.@(js|css|eot|ttf|woff)"
+        ]
+      },
+      {
         "basePath": "",
         "files": [
-          "dist/**/*.@(js|css|eot|ttf|woff)",
           "plugin/**/*.@(js|css)"
         ]
       }

--- a/packages/r/reveal.js.json
+++ b/packages/r/reveal.js.json
@@ -16,8 +16,8 @@
       {
         "basePath": "",
         "files": [
-          "dist/**",
-          "plugin/**"
+          "dist/**/*.@(js|css|eot|ttf|woff)",
+          "plugin/**/*.@(js|css)"
         ]
       }
     ]


### PR DESCRIPTION
We relocated most of our distributed assets in reveal.js 4.0. This PR updates the filemap to cover the new paths.