### PR TITLE
Update shadydom w/ npm auto-update

### DIFF
--- a/packages/s/shadydom.json
+++ b/packages/s/shadydom.json
@@ -14,18 +14,18 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/webcomponents/shadydom.git"
+    "url": "https://github.com/webcomponents/polyfills.git"
   },
   "author": "The Polymer Authors",
   "homepage": "https://webcomponents.org/polyfills",
   "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/webcomponents/shadydom.git",
+    "source": "npm",
+    "target": "@webcomponents/shadydom",
     "fileMap": [
       {
         "basePath": "",
         "files": [
-          "shadydom*"
+          "shadydom.min.js?(.map)"
         ]
       }
     ]


### PR DESCRIPTION
The old repository is archived[1] and the new repository contains a lot
of tags for other polyfills, so switching to NPM seems to be the only
solution.

[1] https://github.com/webcomponents/shadydom
[2] https://github.com/webcomponents/polyfills/tags

Refs #302