### PR TITLE
Add caf w/ npm auto-update

### DIFF
--- a/packages/c/caf.json
+++ b/packages/c/caf.json
@@ -1,0 +1,30 @@
+{
+  "name": "caf",
+  "description": "Cancelable Async Flows: a wrapper to treat generators as cancelable async functions",
+  "filename": "caf.js",
+  "keywords": [
+    "async",
+    "promises",
+    "generators",
+    "cancelation"
+  ],
+  "author": "Kyle Simpson <getify@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/getify/caf.git"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/getify/caf",
+  "autoupdate": {
+    "source": "npm",
+    "target": "caf",
+    "fileMap": [
+      {
+        "basePath": "dist",
+        "files": [
+          "**/*"
+        ]
+      }
+    ]
+  }
+}

--- a/packages/c/caf.json
+++ b/packages/c/caf.json
@@ -22,7 +22,7 @@
       {
         "basePath": "dist",
         "files": [
-          "**/*"
+          "**/*.?(js|json|mjs|map)"
         ]
       }
     ]


### PR DESCRIPTION
Library name: caf
Git repository url: https://github.com/getify/caf
npm package name or url (if there is one) : caf
License (List them all if it's multiple): MIT
Official homepage: https://github.com/getify/caf