### PR TITLE
Update hack-font  w/ npm auto-update

### DIFF
--- a/packages/h/hack-font.json
+++ b/packages/h/hack-font.json
@@ -25,8 +25,8 @@
   ],
   "homepage": "https://sourcefoundry.org/hack/",
   "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/source-foundry/Hack.git",
+    "source": "npm",
+    "target": "hack-font",
     "fileMap": [
       {
         "basePath": "build",


### PR DESCRIPTION
We require the version to be in the semver format[1] and the git tags
isn't[2], so let's switch to NPM.

[1] https://github.com/cdnjs/tools/pull/79
[2] https://github.com/source-foundry/Hack/tags

Refs #302