### PR TITLE
Add monio w/ npm auto-update

### DIFF
--- a/packages/m/monio.json
+++ b/packages/m/monio.json
@@ -23,7 +23,8 @@
       {
         "basePath": "dist",
         "files": [
-          "**/*"
+          "umd/*.?(js|json|map)",
+          "esm/*.?(js|mjs|json|map)"
         ]
       }
     ]

--- a/packages/m/monio.json
+++ b/packages/m/monio.json
@@ -1,0 +1,31 @@
+{
+  "name": "monio",
+  "description": "async-capable IO Monad (including \"do\" style) for JS",
+  "filename": "umd/bundle.js",
+  "keywords": [
+    "fp",
+    "monad",
+    "async",
+    "io",
+    "promise"
+  ],
+  "author": "Kyle Simpson <getify@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/getify/monio.git"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/getify/monio",
+  "autoupdate": {
+    "source": "npm",
+    "target": "monio",
+    "fileMap": [
+      {
+        "basePath": "dist",
+        "files": [
+          "**/*"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Library name: monio
Git repository url: https://github.com/getify/monio
npm package name or url (if there is one) : monio
License (List them all if it's multiple): MIT
Official homepage: https://github.com/getify/monio