### PR TITLE
Standardizing license field

### DIFF
--- a/packages/9/960gs.json
+++ b/packages/9/960gs.json
@@ -12,8 +12,5 @@
     "type": "git",
     "url": "https://github.com/nathansmith/960-Grid-System/"
   },
-  "licenses": [
-    "GPL",
-    "MIT"
-  ]
+  "license": "(GPL OR MIT)"
 }

--- a/packages/a/a-happy-tyler.json
+++ b/packages/a/a-happy-tyler.json
@@ -1,15 +1,14 @@
 {
   "name": "a-happy-tyler",
   "description": "Tyler is happy. Be like Tyler.",
-  "keywords": [],
-  "author": {
-    "name": "Tyler Caslin",
-    "email": "tylercaslin47@gmail.com"
-  },
   "keywords": [
     "tyler",
     "happy"
   ],
+  "author": {
+    "name": "Tyler Caslin",
+    "email": "tylercaslin47@gmail.com"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/a/academicons.json
+++ b/packages/a/academicons.json
@@ -27,13 +27,10 @@
     "type": "git",
     "url": "git://github.com/jpswalsh/academicons.git"
   },
-  "licenses": [
-    "OFL-1.1",
-    "MIT"
-  ],
   "author": {
     "name": "James Walsh",
     "email": "james.walsh@northwestern.edu",
     "url": "http://jpswalsh.com/"
-  }
+  },
+  "license": "(OFL-1.1 OR MIT)"
 }

--- a/packages/a/ajile.json
+++ b/packages/a/ajile.json
@@ -24,11 +24,6 @@
     "type": "git",
     "url": "https://github.com/iskitz/ajile.git"
   },
-  "licenses": [
-    "MPL-1.1",
-    "LGPL-2.1",
-    "GPL-2.0"
-  ],
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/iskitz/ajile.git",
@@ -42,5 +37,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MPL-1.1 OR LGPL-2.1 OR GPL-2.0)"
 }

--- a/packages/a/amcharts.json
+++ b/packages/a/amcharts.json
@@ -9,10 +9,7 @@
   ],
   "homepage": "https://www.amcharts.com/",
   "author": "amCharts <contact@amcharts.com>",
-  "license": {
-    "name": "Free and commercial",
-    "url": "https://www.amcharts.com/download/"
-  },
+  "license": "Free and commercial",
   "repository": {
     "type": "git",
     "url": "https://github.com/amcharts/amcharts3.git"

--- a/packages/a/amcharts4.json
+++ b/packages/a/amcharts4.json
@@ -8,10 +8,7 @@
     "javascript",
     "charts"
   ],
-  "license": {
-    "name": "Free and commercial",
-    "url": "https://github.com/amcharts/amcharts4/blob/master/dist/script/LICENSE"
-  },
+  "license": "Free and commercial",
   "name": "amcharts4",
   "repository": {
     "type": "git",

--- a/packages/a/ammaps.json
+++ b/packages/a/ammaps.json
@@ -9,16 +9,7 @@
   ],
   "author": "amCharts <contact@amcharts.com>",
   "homepage": "https://www.amcharts.com/",
-  "licenses": [
-    {
-      "type": "Custom",
-      "url": "https://github.com/amcharts/ammap3/blob/master/licence.txt"
-    },
-    {
-      "type": "Commercial License",
-      "url": "https://github.com/amcharts/ammap3#commercial-license"
-    }
-  ],
+  "licenses": "(Custom OR Commercial License)",
   "repository": {
     "type": "git",
     "url": "https://github.com/amcharts/ammap3.git"

--- a/packages/a/ammaps.json
+++ b/packages/a/ammaps.json
@@ -9,7 +9,7 @@
   ],
   "author": "amCharts <contact@amcharts.com>",
   "homepage": "https://www.amcharts.com/",
-  "licenses": "(Custom OR Commercial License)",
+  "license": "(Custom OR Commercial License)",
   "repository": {
     "type": "git",
     "url": "https://github.com/amcharts/ammap3.git"

--- a/packages/a/amplifyjs.json
+++ b/packages/a/amplifyjs.json
@@ -24,9 +24,6 @@
     "type": "git",
     "url": "https://github.com/mikehostetler/amplify"
   },
-  "licenses": [
-    "MIT",
-    "GPL"
-  ],
-  "author": "appendTo (http://appendto.com/)"
+  "author": "appendTo (http://appendto.com/)",
+  "license": "(MIT OR GPL)"
 }

--- a/packages/a/amstockchart.json
+++ b/packages/a/amstockchart.json
@@ -6,8 +6,5 @@
     "chart"
   ],
   "homepage": "http://www.amcharts.com/",
-  "license": {
-    "name": "Free and commercial",
-    "url": "http://www.amcharts.com/download/"
-  }
+  "license": "Free and commercial"
 }

--- a/packages/a/angular-busy.json
+++ b/packages/a/angular-busy.json
@@ -30,7 +30,5 @@
       }
     ]
   },
-  "license": {
-    "url": "https://github.com/cgross/angular-busy/blob/master/LICENSE"
-  }
+  "license": "MIT"
 }

--- a/packages/b/bitset.js.json
+++ b/packages/b/bitset.js.json
@@ -35,8 +35,5 @@
       }
     ]
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ]
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/c/cc-icons.json
+++ b/packages/c/cc-icons.json
@@ -11,10 +11,6 @@
     "library",
     "icons"
   ],
-  "licenses": [
-    "MIT",
-    "CC-BY-4.0"
-  ],
   "author": {
     "name": "richardba",
     "email": "richard at gmail dot com",
@@ -41,5 +37,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR CC-BY-4.0)"
 }

--- a/packages/c/colresizable.json
+++ b/packages/c/colresizable.json
@@ -34,8 +34,5 @@
       }
     ]
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ]
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/c/concretejs.json
+++ b/packages/c/concretejs.json
@@ -10,10 +10,6 @@
     "name": "Eric Rowell",
     "url": "https://twitter.com/ericdrowell"
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ],
   "keywords": [
     "concrete",
     "html5",
@@ -34,5 +30,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/c/crafty.json
+++ b/packages/c/crafty.json
@@ -7,13 +7,7 @@
     "name": "Louis Stowasser",
     "url": "http://craftyjs.com/"
   },
-  "licenses": [
-    "MIT",
-    {
-      "type": "GPL",
-      "url": "http://www.opensource.org/licenses/gpl-license.php"
-    }
-  ],
+  "license": "(MIT OR GPL)",
   "description": "Crafty is a modern component and event based framework for javascript games that targets DOM and canvas.",
   "keywords": [
     "framework",

--- a/packages/c/css3pie.json
+++ b/packages/c/css3pie.json
@@ -11,12 +11,9 @@
     "css3",
     "pie"
   ],
-  "licenses": [
-    "Apache-2.0",
-    "GPL-2.0"
-  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/lojjic/PIE"
-  }
+  },
+  "license": "(Apache-2.0 OR GPL-2.0)"
 }

--- a/packages/d/Detect.js.json
+++ b/packages/d/Detect.js.json
@@ -2,10 +2,6 @@
   "name": "Detect.js",
   "filename": "detect.min.js",
   "author": "Darcy Clarke",
-  "licenses": [
-    "MIT",
-    "GPL"
-  ],
   "description": "JS Library to detect browser, os and device based on the UserAgent String",
   "repository": {
     "type": "git",
@@ -30,5 +26,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL)"
 }

--- a/packages/d/DragDrop.json
+++ b/packages/d/DragDrop.json
@@ -6,10 +6,6 @@
     "type": "git",
     "url": "https://github.com/kbjr/DragDrop.git"
   },
-  "licenses": [
-    "MIT",
-    "GPL-3.0"
-  ],
   "author": "James Brumond",
   "homepage": "https://kbjr.github.io/DragDrop/index.html",
   "keywords": [
@@ -28,5 +24,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-3.0)"
 }

--- a/packages/d/design-system.json
+++ b/packages/d/design-system.json
@@ -3,10 +3,6 @@
   "filename": "styles/salesforce-lightning-design-system.min.css",
   "description": "Salesforce Lightning Design System",
   "author": "Salesforce",
-  "licenses": [
-    "BSD-3-Clause",
-    "CC-BY-ND-4.0"
-  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/salesforce-ux/design-system.git"
@@ -27,5 +23,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(BSD-3-Clause OR CC-BY-ND-4.0)"
 }

--- a/packages/d/dinqyjs.json
+++ b/packages/d/dinqyjs.json
@@ -14,8 +14,5 @@
     "type": "git",
     "url": "https://github.com/garrypas/dinqyjs"
   },
-  "licenses": [
-    "MIT",
-    "Apache-2.0"
-  ]
+  "license": "(MIT OR Apache-2.0)"
 }

--- a/packages/d/docxtemplater.json
+++ b/packages/d/docxtemplater.json
@@ -14,10 +14,6 @@
     "type": "git",
     "url": "https://github.com/open-xml-templating/docxtemplater"
   },
-  "licenses": [
-    "MIT",
-    "GPL-3.0"
-  ],
   "autoupdate": {
     "source": "npm",
     "target": "docxtemplater",
@@ -29,5 +25,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-3.0)"
 }

--- a/packages/d/dojo.json
+++ b/packages/d/dojo.json
@@ -9,10 +9,6 @@
     "dojo",
     "JavaScript"
   ],
-  "licenses": [
-    "AFL-2.1",
-    "BSD"
-  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/dojo/dojo.git"
@@ -29,5 +25,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(AFL-2.1 OR BSD)"
 }

--- a/packages/d/dompurify.json
+++ b/packages/d/dompurify.json
@@ -20,10 +20,6 @@
     "purify"
   ],
   "author": "Mario Heiderich <mario@cure53.de> (https://cure53.de/)",
-  "licenses": [
-    "MPL-2.0",
-    "Apache-2.0"
-  ],
   "homepage": "https://cure53.de/purify",
   "autoupdate": {
     "source": "git",
@@ -36,5 +32,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MPL-2.0 OR Apache-2.0)"
 }

--- a/packages/e/easy-countdown.json
+++ b/packages/e/easy-countdown.json
@@ -13,10 +13,6 @@
     "plugin"
   ],
   "author": "Robert Fleischmann <me@robert-fleischmann.de>",
-  "licenses": [
-    "MIT",
-    "GPL-3.0"
-  ],
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/rendro/countdown.git",
@@ -28,5 +24,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-3.0)"
 }

--- a/packages/e/easy-pie-chart.json
+++ b/packages/e/easy-pie-chart.json
@@ -31,8 +31,5 @@
     "email": "rendro87@gmail.com",
     "url": "http://robert-fleischmann.de"
   },
-  "licenses": [
-    "MIT",
-    "GPL-3.0"
-  ]
+  "license": "(MIT OR GPL-3.0)"
 }

--- a/packages/e/entypo.json
+++ b/packages/e/entypo.json
@@ -13,8 +13,5 @@
     "type": "git",
     "url": "https://github.com/danielbruce/entypo.git"
   },
-  "licenses": [
-    "CC-BY-SA-3.0",
-    "OFL-1.1"
-  ]
+  "license": "(CC-BY-SA-3.0 OR OFL-1.1)"
 }

--- a/packages/e/equalize.js.json
+++ b/packages/e/equalize.js.json
@@ -14,10 +14,6 @@
     "name": "Tim Svensen",
     "url": "http://timsvensen.com"
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ],
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/tsvensen/equalize.js.git",
@@ -34,5 +30,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/tsvensen/equalize.js/blob/master/js/equalize.js"
-  }
+  },
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/e/evil.js.json
+++ b/packages/e/evil.js.json
@@ -8,9 +8,7 @@
     "evil",
     "evil.js"
   ],
-  "license": {
-    "type": "Public Domain"
-  },
+  "license": "Public Domain",
   "repository": {
     "type": "git",
     "url": "https://github.com/kitcambridge/evil.js.git"

--- a/packages/e/extjs.json
+++ b/packages/e/extjs.json
@@ -9,18 +9,5 @@
     "desktop",
     "popular"
   ],
-  "licenses": [
-    {
-      "type": "GNU General Public License Version 3",
-      "url": "http://www.gnu.org/licenses/gpl.html"
-    },
-    {
-      "type": "Open Source License Exception for Applications",
-      "url": "http://www.sencha.com/products/floss-exception.php"
-    },
-    {
-      "type": "Open Source License Exception for Development",
-      "url": "http://www.sencha.com/products/ux-exception.php"
-    }
-  ]
+  "license": "(GNU General Public License Version 3 OR Open Source License Exception for Applications OR Open Source License Exception for Development)"
 }

--- a/packages/f/fancybox.json
+++ b/packages/f/fancybox.json
@@ -16,13 +16,7 @@
     "type": "git",
     "url": "https://github.com/fancyapps/fancybox"
   },
-  "licenses": [
-    {
-      "type": "fancyBox",
-      "url": "https://fancyapps.com/fancybox/3/#license"
-    },
-    "GPL-3.0"
-  ],
+  "license": "GPL-3.0",
   "author": "Jānis Skarnelis",
   "autoupdate": {
     "source": "git",

--- a/packages/f/fatcow-icons.json
+++ b/packages/f/fatcow-icons.json
@@ -7,8 +7,5 @@
     "fatcow"
   ],
   "homepage": "http://www.fatcow.com/free-icons",
-  "license": {
-    "name": "Creative Commons Attribution 3.0",
-    "url": "http://creativecommons.org/licenses/by/3.0/us/"
-  }
+  "license": "Creative Commons Attribution 3.0"
 }

--- a/packages/f/font-awesome.json
+++ b/packages/f/font-awesome.json
@@ -16,11 +16,6 @@
     "type": "git",
     "url": "git://github.com/FortAwesome/Font-Awesome.git"
   },
-  "licenses": [
-    "OFL-1.1",
-    "MIT",
-    "CC-BY-4.0"
-  ],
   "author": {
     "name": "Dave Gandy",
     "email": "dave@fontawesome.io",
@@ -37,5 +32,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(OFL-1.1 OR MIT OR CC-BY-4.0)"
 }

--- a/packages/f/forge.json
+++ b/packages/f/forge.json
@@ -11,10 +11,6 @@
     "type": "git",
     "url": "git+https://github.com/digitalbazaar/forge.git"
   },
-  "licenses": [
-    "BSD-3-Clause",
-    "GPL-2.0"
-  ],
   "keywords": [
     "aes",
     "asn",
@@ -55,5 +51,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(BSD-3-Clause OR GPL-2.0)"
 }

--- a/packages/f/fork-awesome.json
+++ b/packages/f/fork-awesome.json
@@ -15,10 +15,6 @@
     "type": "git",
     "url": "https://github.com/ForkAwesome/Fork-Awesome.git"
   },
-  "licenses": [
-    "OFL-1.1",
-    "MIT"
-  ],
   "autoupdate": {
     "source": "npm",
     "target": "fork-awesome",
@@ -30,5 +26,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(OFL-1.1 OR MIT)"
 }

--- a/packages/f/froala-design-blocks.json
+++ b/packages/f/froala-design-blocks.json
@@ -14,10 +14,7 @@
     "html5",
     "trending design"
   ],
-  "license": {
-    "type": "Custom license",
-    "url": "https://github.com/froala/design-blocks/blob/master/LICENSE"
-  },
+  "license": "Custom license",
   "repository": {
     "type": "git",
     "url": "git://github.com/froala/design-blocks.git"

--- a/packages/f/froala-editor.json
+++ b/packages/f/froala-editor.json
@@ -24,20 +24,7 @@
       }
     ]
   },
-  "licenses": [
-    {
-      "type": "One Domain",
-      "url": "https://www.froala.com/wysiwyg-editor/pricing"
-    },
-    {
-      "type": "Advanced",
-      "url": "https://www.froala.com/wysiwyg-editor/pricing"
-    },
-    {
-      "type": "OEM",
-      "url": "https://www.froala.com/wysiwyg-editor/pricing"
-    }
-  ],
+  "license": "(One Domain OR Advanced OR OEM)",
   "repository": {
     "type": "git",
     "url": "https://github.com/froala/wysiwyg-editor"

--- a/packages/f/fukol-grids.json
+++ b/packages/f/fukol-grids.json
@@ -7,10 +7,7 @@
     "css",
     "minimal"
   ],
-  "license": {
-    "type": "do as thou wilt",
-    "url": "https://github.com/Heydon/fukol-grids/blob/master/LICENSE.txt"
-  },
+  "license": "do as thou wilt",
   "author": "Heydon Pickering <heydon@heydonworks.com>",
   "autoupdate": {
     "source": "git",

--- a/packages/f/fullcalendar-scheduler.json
+++ b/packages/f/fullcalendar-scheduler.json
@@ -30,12 +30,5 @@
       }
     ]
   },
-  "licenses": [
-    "GPL-3.0",
-    "CC-BY-NC-ND-4.0",
-    {
-      "name": "Commercial License",
-      "url": "https://fullcalendar.io/scheduler/license/"
-    }
-  ]
+  "license": "(GPL-3.0 OR CC-BY-NC-ND-4.0 OR Commercial License)"
 }

--- a/packages/g/geoext.json
+++ b/packages/g/geoext.json
@@ -11,10 +11,7 @@
     "openlayers",
     "maps"
   ],
-  "license": {
-    "type": "BSD",
-    "url": "http://trac.geoext.org/wiki/license"
-  },
+  "license": "BSD",
   "repository": {
     "type": "git",
     "url": "https://github.com/geoext/geoext"

--- a/packages/g/graphiql.json
+++ b/packages/g/graphiql.json
@@ -6,10 +6,7 @@
     "url": "https://github.com/graphql/graphiql.git"
   },
   "filename": "graphiql.min.js",
-  "license": {
-    "type": "customized",
-    "url": "https://github.com/graphql/graphiql/raw/master/LICENSE"
-  },
+  "license": "customized",
   "keywords": [
     "graphiql"
   ],

--- a/packages/g/gsap.json
+++ b/packages/g/gsap.json
@@ -42,8 +42,5 @@
     "name": "Jack Doyle",
     "url": "https://greensock.com"
   },
-  "license": {
-    "name": "Standard 'No Charge' GreenSock License",
-    "url": "https://greensock.com/standard-license"
-  }
+  "license": "Standard 'No Charge' GreenSock License"
 }

--- a/packages/h/hack-font.json
+++ b/packages/h/hack-font.json
@@ -16,13 +16,7 @@
     "type": "git",
     "url": "git+https://github.com/source-foundry/Hack.git"
   },
-  "licenses": [
-    "MIT",
-    {
-      "type": "BITSTREAM VERA LICENSE",
-      "url": "https://github.com/source-foundry/Hack/blob/master/LICENSE.md#bitstream-vera-license"
-    }
-  ],
+  "license": "(MIT OR BITSTREAM VERA LICENSE)",
   "homepage": "https://sourcefoundry.org/hack/",
   "autoupdate": {
     "source": "npm",

--- a/packages/h/hazzik-jquery.livequery.json
+++ b/packages/h/hazzik-jquery.livequery.json
@@ -21,10 +21,6 @@
     "email": "brandon.aaron@gmail.com",
     "url": "http://brandonaaron.net/"
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ],
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/hazzik/livequery.git",
@@ -36,5 +32,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/h/heatmap.js.json
+++ b/packages/h/heatmap.js.json
@@ -13,10 +13,6 @@
     "googlemaps",
     "leaflet"
   ],
-  "licenses": [
-    "MIT",
-    "Beerware"
-  ],
   "autoupdate": {
     "source": "npm",
     "target": "heatmap.js",
@@ -28,5 +24,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR Beerware)"
 }

--- a/packages/h/html5shiv.json
+++ b/packages/h/html5shiv.json
@@ -24,8 +24,5 @@
       }
     ]
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ]
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/i/IBM-type.json
+++ b/packages/i/IBM-type.json
@@ -13,10 +13,6 @@
     "Plex"
   ],
   "homepage": "https://ibm.github.io/type/",
-  "licenses": [
-    "OFL-1.1",
-    "Apache-2.0"
-  ],
   "autoupdate": {
     "source": "npm",
     "target": "@ibm/type",
@@ -29,5 +25,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(OFL-1.1 OR Apache-2.0)"
 }

--- a/packages/i/Iframe-Height-Jquery-Plugin.json
+++ b/packages/i/Iframe-Height-Jquery-Plugin.json
@@ -14,10 +14,6 @@
     "type": "git",
     "url": "https://github.com/Sly777/Iframe-Height-Jquery-Plugin.git"
   },
-  "licenses": [
-    "MIT",
-    "GPL-3.0"
-  ],
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/Sly777/Iframe-Height-Jquery-Plugin.git",
@@ -29,5 +25,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-3.0)"
 }

--- a/packages/i/IndexedDBShim.json
+++ b/packages/i/IndexedDBShim.json
@@ -13,10 +13,6 @@
     "polyfill",
     "websql"
   ],
-  "licenses": [
-    "Apache-2.0",
-    "MIT"
-  ],
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/axemclion/IndexedDBShim.git",
@@ -28,5 +24,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(Apache-2.0 OR MIT)"
 }

--- a/packages/i/imgareaselect.json
+++ b/packages/i/imgareaselect.json
@@ -15,10 +15,6 @@
     "email": "odyniec@odyniec.net",
     "url": "http://odyniec.net/"
   },
-  "licenses": [
-    "GPL-2.0",
-    "MIT"
-  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/odyniec/imgareaselect"
@@ -34,5 +30,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(GPL-2.0 OR MIT)"
 }

--- a/packages/i/impress.js.json
+++ b/packages/i/impress.js.json
@@ -11,12 +11,9 @@
     "type": "git",
     "url": "https://github.com/impress/impress.js.git"
   },
-  "licenses": [
-    "MIT",
-    "deprecated_GPL-2.0+"
-  ],
   "author": {
     "name": "Bartek Szopka",
     "web": "http://bartaz.github.com"
-  }
+  },
+  "license": "(MIT OR deprecated_GPL-2.0+)"
 }

--- a/packages/i/infusion.json
+++ b/packages/i/infusion.json
@@ -4,10 +4,6 @@
   "filename": "infusion-all.min.js",
   "author": "Fluid Project",
   "homepage": "http://www.fluidproject.org/",
-  "licenses": [
-    "BSD-3-Clause",
-    "ECL-2.0"
-  ],
   "keywords": [
     "infusion",
     "framework",
@@ -33,5 +29,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(BSD-3-Clause OR ECL-2.0)"
 }

--- a/packages/i/intro.js.json
+++ b/packages/i/intro.js.json
@@ -9,10 +9,7 @@
     "introductions"
   ],
   "homepage": "http://usablica.github.com/intro.js/",
-  "license": {
-    "name": "MIT",
-    "url": "https://github.com/usablica/intro.js#license"
-  },
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/usablica/intro.js.git"

--- a/packages/j/jQuery-Paging.json
+++ b/packages/j/jQuery-Paging.json
@@ -16,10 +16,6 @@
     "name": "Robert Eisele",
     "url": "https://www.xarg.org/"
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ],
   "homepage": "https://www.xarg.org/2011/09/jquery-pagination-revised/",
   "autoupdate": {
     "source": "git",
@@ -32,5 +28,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jQuery-slimScroll.json
+++ b/packages/j/jQuery-slimScroll.json
@@ -17,13 +17,7 @@
     "name": "Piotr Rochala",
     "url": "http://rocha.la/"
   },
-  "licenses": [
-    "MIT",
-    {
-      "type": "GPL",
-      "url": "http://www.opensource.org/licenses/gpl-license.php"
-    }
-  ],
+  "license": "(MIT OR GPL)",
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/rochal/jQuery-slimScroll.git",

--- a/packages/j/jQuery-webcam.json
+++ b/packages/j/jQuery-webcam.json
@@ -26,8 +26,5 @@
     ]
   },
   "author": "Robert Eisele <robert@xarg.org>",
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ]
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jQuery.Gantt.json
+++ b/packages/j/jQuery.Gantt.json
@@ -15,10 +15,6 @@
     "name": "Marek Bielańczuk",
     "url": "https://github.com/mbielanczuk"
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ],
   "homepage": "http://mbielanczuk.com/jquery-gantt/",
   "autoupdate": {
     "source": "git",
@@ -33,5 +29,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jQuery.scrollSpeed.json
+++ b/packages/j/jQuery.scrollSpeed.json
@@ -13,8 +13,5 @@
     "scrolling",
     "easing"
   ],
-  "licenses": [
-    "MIT",
-    "CC0-1.0"
-  ]
+  "license": "(MIT OR CC0-1.0)"
 }

--- a/packages/j/jReject.json
+++ b/packages/j/jReject.json
@@ -11,10 +11,6 @@
     "name": "Steven Bower",
     "url": "https://github.com/BluSyn"
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ],
   "homepage": "http://jreject.turnwheel.com",
   "repository": {
     "type": "git",
@@ -34,5 +30,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jScrollPane.json
+++ b/packages/j/jScrollPane.json
@@ -29,8 +29,5 @@
     "type": "git",
     "url": "https://github.com/vitch/jScrollPane.git"
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ]
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/javascript-debug.json
+++ b/packages/j/javascript-debug.json
@@ -12,10 +12,6 @@
     "cross-browser"
   ],
   "author": "Ben Alman",
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ],
   "homepage": "http://benalman.com/projects/javascript-debug-console-log",
   "autoupdate": {
     "source": "git",
@@ -28,5 +24,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jqModal.json
+++ b/packages/j/jqModal.json
@@ -23,11 +23,8 @@
     "type": "git",
     "url": "git://github.com/briceburg/jqModal.git"
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ],
   "author": {
     "name": "Brice Burgess"
-  }
+  },
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jqPlot.json
+++ b/packages/j/jqPlot.json
@@ -11,14 +11,10 @@
     "plotting",
     "graphing"
   ],
-  "licenses": [
-    "MIT",
-    "GPL-2.0",
-    "CC-BY-3.0"
-  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/jqPlot/jqPlot/"
   },
-  "author": "Chris Leonello <chris@jqplot.com>"
+  "author": "Chris Leonello <chris@jqplot.com>",
+  "license": "(MIT OR GPL-2.0 OR CC-BY-3.0)"
 }

--- a/packages/j/jquery-dateFormat.json
+++ b/packages/j/jquery-dateFormat.json
@@ -13,9 +13,6 @@
     "type": "git",
     "url": "https://github.com/phstc/jquery-dateFormat.git"
   },
-  "licenses": [
-    "MIT",
-    "GPL"
-  ],
-  "author": "Pablo Cantero <pablo@pablocantero.com>"
+  "author": "Pablo Cantero <pablo@pablocantero.com>",
+  "license": "(MIT OR GPL)"
 }

--- a/packages/j/jquery-details.json
+++ b/packages/j/jquery-details.json
@@ -17,10 +17,6 @@
     "type": "git",
     "url": "https://github.com/mathiasbynens/jquery-details.git"
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ],
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/mathiasbynens/jquery-details.git",
@@ -32,5 +28,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jquery-dotimeout.json
+++ b/packages/j/jquery-dotimeout.json
@@ -8,10 +8,6 @@
     "doTimeout",
     "jQuery"
   ],
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ],
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/cowboy/jquery-dotimeout.git",
@@ -27,5 +23,6 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/cowboy/jquery-dotimeout.git"
-  }
+  },
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jquery-easing.json
+++ b/packages/j/jquery-easing.json
@@ -16,10 +16,6 @@
     "email": "george@gsgd.co.uk",
     "url": "http://gsgd.co.uk/"
   },
-  "licenses": [
-    "MIT",
-    "BSD-3-Clause"
-  ],
   "autoupdate": {
     "source": "npm",
     "target": "jquery.easing",
@@ -31,5 +27,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR BSD-3-Clause)"
 }

--- a/packages/j/jquery-endless-scroll.json
+++ b/packages/j/jquery-endless-scroll.json
@@ -7,10 +7,6 @@
     "endless",
     "scroll"
   ],
-  "licenses": [
-    "MIT",
-    "GPL-3.0"
-  ],
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/fredwu/jquery-endless-scroll.git",
@@ -27,5 +23,6 @@
     "type": "git",
     "url": "https://github.com/fredwu/jquery-endless-scroll.git"
   },
-  "author": "Fred Wu"
+  "author": "Fred Wu",
+  "license": "(MIT OR GPL-3.0)"
 }

--- a/packages/j/jquery-hashchange.json
+++ b/packages/j/jquery-hashchange.json
@@ -23,8 +23,5 @@
       }
     ]
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ]
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jquery-infinitescroll.json
+++ b/packages/j/jquery-infinitescroll.json
@@ -29,12 +29,6 @@
     "type": "git",
     "url": "git://github.com/metafizzy/infinite-scroll.git"
   },
-  "licenses": [
-    "GPL-3.0",
-    {
-      "type": "Commercial License",
-      "url": "https://github.com/metafizzy/infinite-scroll#commercial-license"
-    }
-  ],
+  "license": "(GPL-3.0 OR Commercial License)",
   "author": "Metafizzy"
 }

--- a/packages/j/jquery-layout.json
+++ b/packages/j/jquery-layout.json
@@ -25,8 +25,5 @@
     "type": "git",
     "url": "git://github.com/allpro/layout.git"
   },
-  "licenses": [
-    "MIT",
-    "GPL-3.0"
-  ]
+  "license": "(MIT OR GPL-3.0)"
 }

--- a/packages/j/jquery-mockjax.json
+++ b/packages/j/jquery-mockjax.json
@@ -10,13 +10,7 @@
   ],
   "author": "Jonathan Sharp (http://jdsharp.com/)",
   "homepage": "http://code.appendto.com/plugins/jquery-mockjax/",
-  "licenses": [
-    "MIT",
-    {
-      "type": "GPLv2",
-      "url": "http://appendto.com/open-source-licenses"
-    }
-  ],
+  "license": "(MIT OR GPLv2)",
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/jakerella/jquery-mockjax.git",

--- a/packages/j/jquery-once.json
+++ b/packages/j/jquery-once.json
@@ -11,10 +11,6 @@
     "type": "git",
     "url": "https://github.com/RobLoach/jquery-once.git"
   },
-  "licenses": [
-    "GPL-2.0",
-    "MIT"
-  ],
   "autoupdate": {
     "source": "npm",
     "target": "jquery-once",
@@ -28,5 +24,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(GPL-2.0 OR MIT)"
 }

--- a/packages/j/jquery-outside-events.json
+++ b/packages/j/jquery-outside-events.json
@@ -22,8 +22,5 @@
       }
     ]
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ]
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jquery-parallax.json
+++ b/packages/j/jquery-parallax.json
@@ -12,8 +12,5 @@
     "type": "git",
     "url": "https://github.com/IanLunn/jQuery-Parallax"
   },
-  "licenses": [
-    "MIT",
-    "GPL-3.0"
-  ]
+  "license": "(MIT OR GPL-3.0)"
 }

--- a/packages/j/jquery-replace-text.json
+++ b/packages/j/jquery-replace-text.json
@@ -13,10 +13,6 @@
     "type": "git",
     "url": "https://github.com/cowboy/jquery-replacetext"
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ],
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/cowboy/jquery-replacetext.git",
@@ -28,5 +24,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jquery-resize.json
+++ b/packages/j/jquery-resize.json
@@ -22,8 +22,5 @@
     "type": "git",
     "url": "https://github.com/cowboy/jquery-resize"
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ]
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jquery-teletype-plugin.json
+++ b/packages/j/jquery-teletype-plugin.json
@@ -24,8 +24,5 @@
   },
   "author": "Steve Whiteley",
   "homepage": "http://teletype.rocks/",
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ]
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jquery-throttle-debounce.json
+++ b/packages/j/jquery-throttle-debounce.json
@@ -24,8 +24,5 @@
       }
     ]
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ]
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jquery-tokeninput.json
+++ b/packages/j/jquery-tokeninput.json
@@ -12,10 +12,6 @@
   ],
   "author": "James Smith <james@loopj.com> (https://loopj.com)",
   "homepage": "https://loopj.com/jquery-tokeninput/",
-  "licenses": [
-    "MIT",
-    "GPL-3.0"
-  ],
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/loopj/jquery-tokeninput.git",
@@ -33,5 +29,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-3.0)"
 }

--- a/packages/j/jquery-ui-bootstrap.json
+++ b/packages/j/jquery-ui-bootstrap.json
@@ -6,10 +6,7 @@
     "jquery",
     "bootstrap"
   ],
-  "license": {
-    "name": "MIT License",
-    "url": "http://www.opensource.org/licenses/mit-license.php"
-  },
+  "license": "MIT License",
   "repository": {
     "type": "git",
     "url": "https://github.com/jquery-ui-bootstrap/jquery-ui-bootstrap.git"

--- a/packages/j/jquery-ui-multiselect-widget.json
+++ b/packages/j/jquery-ui-multiselect-widget.json
@@ -16,10 +16,6 @@
     "type": "git",
     "url": "https://github.com/ehynds/jquery-ui-multiselect-widget"
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ],
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/ehynds/jquery-ui-multiselect-widget.git",
@@ -37,5 +33,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jquery.ba-bbq.json
+++ b/packages/j/jquery.ba-bbq.json
@@ -23,8 +23,5 @@
     "type": "git",
     "url": "https://github.com/cowboy/jquery-bbq"
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ]
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jquery.blockUI.json
+++ b/packages/j/jquery.blockUI.json
@@ -13,10 +13,6 @@
     "name": "M. Alsup",
     "url": "http://jquery.malsup.com"
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/malsup/blockui"
@@ -32,5 +28,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jquery.bootstrapvalidator.json
+++ b/packages/j/jquery.bootstrapvalidator.json
@@ -27,10 +27,7 @@
     "type": "git",
     "url": "https://github.com/nghuuphuoc/bootstrapvalidator.git"
   },
-  "license": {
-    "type": "customized",
-    "url": "http://bootstrapvalidator.com/license/"
-  },
+  "license": "customized",
   "author": {
     "name": "Nguyen Huu Phuoc",
     "email": "phuoc@huuphuoc.me",

--- a/packages/j/jquery.caroufredsel.json
+++ b/packages/j/jquery.caroufredsel.json
@@ -12,12 +12,9 @@
     "responsive",
     "jquery"
   ],
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/gilbitron/carouFredSel.git"
-  }
+  },
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jquery.customSelect.json
+++ b/packages/j/jquery.customSelect.json
@@ -11,8 +11,5 @@
     "type": "git",
     "url": "https://github.com/adamcoulombe/jquery.customSelect"
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ]
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jquery.cycle.json
+++ b/packages/j/jquery.cycle.json
@@ -24,8 +24,5 @@
       }
     ]
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ]
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jquery.easytabs.json
+++ b/packages/j/jquery.easytabs.json
@@ -12,8 +12,5 @@
     "type": "git",
     "url": "https://github.com/JangoSteve/jQuery-EasyTabs"
   },
-  "licenses": [
-    "MIT",
-    "GPL"
-  ]
+  "license": "(MIT OR GPL)"
 }

--- a/packages/j/jquery.form.json
+++ b/packages/j/jquery.form.json
@@ -19,10 +19,6 @@
     "url": "https://github.com/jquery-form/form.git"
   },
   "author": "Kevin Morris",
-  "licenses": [
-    "MIT",
-    "LGPL-2.1"
-  ],
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/jquery-form/form.git",
@@ -40,5 +36,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR LGPL-2.1)"
 }

--- a/packages/j/jquery.formalize.json
+++ b/packages/j/jquery.formalize.json
@@ -13,8 +13,5 @@
     "type": "git",
     "url": "https://github.com/nathansmith/formalize"
   },
-  "licenses": [
-    "MIT",
-    "GPL-3.0"
-  ]
+  "license": "(MIT OR GPL-3.0)"
 }

--- a/packages/j/jquery.i18n.json
+++ b/packages/j/jquery.i18n.json
@@ -31,8 +31,5 @@
       }
     ]
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ]
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jquery.ime.json
+++ b/packages/j/jquery.ime.json
@@ -41,8 +41,5 @@
       }
     ]
   },
-  "licenses": [
-    "GPL-2.0",
-    "MIT"
-  ]
+  "license": "(GPL-2.0 OR MIT)"
 }

--- a/packages/j/jquery.lazy.json
+++ b/packages/j/jquery.lazy.json
@@ -31,10 +31,6 @@
     "retina",
     "placeholder"
   ],
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ],
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/eisbehr-/jquery.lazy.git",
@@ -47,5 +43,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jquery.mb.YTPlayer.json
+++ b/packages/j/jquery.mb.YTPlayer.json
@@ -33,8 +33,5 @@
     "type": "git",
     "url": "git://github.com/pupunzi/jquery.mb.YTPlayer.git"
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ]
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jquery.mb.bgndgallery.json
+++ b/packages/j/jquery.mb.bgndgallery.json
@@ -12,10 +12,6 @@
     "HTML5"
   ],
   "author": "Pupunzi <matteo@open-lab.com> (Matteo Bicocchi)",
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ],
   "homepage": "https://pupunzi.open-lab.com/mb-jquery-components/jquery-mb-bgndgallery/",
   "repository": {
     "type": "git",
@@ -32,5 +28,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jquery.pin.json
+++ b/packages/j/jquery.pin.json
@@ -8,10 +8,7 @@
     "pin"
   ],
   "homepage": "http://webpop.github.com/jquery.pin/",
-  "license": {
-    "name": "Personalized License",
-    "url": "https://github.com/webpop/jquery.pin#license"
-  },
+  "license": "Personalized License",
   "repository": {
     "type": "git",
     "url": "https://github.com/webpop/jquery.pin.git"

--- a/packages/j/jquery.pjax.json
+++ b/packages/j/jquery.pjax.json
@@ -22,9 +22,7 @@
       }
     ]
   },
-  "license": {
-    "url": "https://github.com/defunkt/jquery-pjax/blob/master/LICENSE"
-  },
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/defunkt/jquery-pjax"

--- a/packages/j/jquery.spritely.json
+++ b/packages/j/jquery.spritely.json
@@ -17,8 +17,5 @@
     "email": "team@spritely.net",
     "web": "http://www.artlogic.net"
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ]
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jquery.tablesorter.json
+++ b/packages/j/jquery.tablesorter.json
@@ -16,10 +16,6 @@
     "alphanumeric",
     "natural"
   ],
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ],
   "homepage": "http://mottie.github.com/tablesorter/",
   "repository": {
     "type": "git",
@@ -36,5 +32,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jquery.tiptip.json
+++ b/packages/j/jquery.tiptip.json
@@ -6,13 +6,10 @@
     "tiptip",
     "tooltip"
   ],
-  "licenses": [
-    "MIT",
-    "GPL-3.0"
-  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/drewwilson/TipTip"
   },
-  "filename": "jquery.tipTip.minified.js"
+  "filename": "jquery.tipTip.minified.js",
+  "license": "(MIT OR GPL-3.0)"
 }

--- a/packages/j/jquery.touchswipe.json
+++ b/packages/j/jquery.touchswipe.json
@@ -25,11 +25,8 @@
     "type": "git",
     "url": "https://github.com/mattbryson/TouchSwipe-Jquery-Plugin.git"
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ],
   "author": {
     "name": "Matt Bryson"
-  }
+  },
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jquery.webticker.json
+++ b/packages/j/jquery.webticker.json
@@ -41,11 +41,5 @@
     ]
   },
   "homepage": "https://maze.digital/webticker/",
-  "licenses": [
-    "GPL-3.0",
-    {
-      "type": "Commercial License",
-      "url": "https://maze.digital/webticker/license/#commercial"
-    }
-  ]
+  "license": "(GPL-3.0 OR Commercial License)"
 }

--- a/packages/j/jquerymobile-router.json
+++ b/packages/j/jquerymobile-router.json
@@ -12,10 +12,6 @@
     "jquerymobile-router",
     "jQM"
   ],
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ],
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/azicchetti/jquerymobile-router.git",
@@ -27,5 +23,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jqueryui-touch-punch.json
+++ b/packages/j/jqueryui-touch-punch.json
@@ -12,10 +12,6 @@
     "type": "git",
     "url": "https://github.com/furf/jquery-ui-touch-punch.git"
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ],
   "autoupdate": {
     "source": "npm",
     "target": "jquery-ui-touch-punch",
@@ -27,5 +23,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jqvmap.json
+++ b/packages/j/jqvmap.json
@@ -8,10 +8,6 @@
     "name": "JQVMap",
     "url": "http://jqvmap.com"
   },
-  "licenses": [
-    "MIT",
-    "GPL-3.0"
-  ],
   "keywords": [
     "jquery",
     "map",
@@ -34,5 +30,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-3.0)"
 }

--- a/packages/j/jsPlumb.json
+++ b/packages/j/jsPlumb.json
@@ -16,10 +16,6 @@
     "type": "git",
     "url": "https://github.com/jsplumb/jsPlumb.git"
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ],
   "author": "Simon Porritt",
   "autoupdate": {
     "source": "npm",
@@ -38,5 +34,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/j/jschannel.json
+++ b/packages/j/jschannel.json
@@ -14,9 +14,5 @@
     "type": "git",
     "url": "https://github.com/mozilla/jschannel.git"
   },
-  "licenses": [
-    "MPL-1.1",
-    "GPL-2.0",
-    "LGPL-2.1"
-  ]
+  "license": "(MPL-1.1 OR GPL-2.0 OR LGPL-2.1)"
 }

--- a/packages/j/jsts.json
+++ b/packages/j/jsts.json
@@ -16,10 +16,6 @@
     "url": "git://github.com/bjornharrtell/jsts.git"
   },
   "homepage": "https://bjornharrtell.github.io/jsts/",
-  "licenses": [
-    "EDL-1.0",
-    "EPL-1.0"
-  ],
   "autoupdate": {
     "source": "npm",
     "target": "jsts",
@@ -31,5 +27,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(EDL-1.0 OR EPL-1.0)"
 }

--- a/packages/j/jsxgraph.json
+++ b/packages/j/jsxgraph.json
@@ -32,8 +32,5 @@
     ]
   },
   "namespace": "JXG",
-  "licenses": [
-    "MIT",
-    "LGPL-3.0"
-  ]
+  "license": "(MIT OR LGPL-3.0)"
 }

--- a/packages/j/jszip-utils.json
+++ b/packages/j/jszip-utils.json
@@ -14,10 +14,6 @@
     "IE",
     "Internet Explorer"
   ],
-  "licenses": [
-    "MIT",
-    "GPL-3.0"
-  ],
   "homepage": "https://stuk.github.io/jszip-utils",
   "autoupdate": {
     "source": "npm",
@@ -30,5 +26,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-3.0)"
 }

--- a/packages/j/jszip.json
+++ b/packages/j/jszip.json
@@ -25,9 +25,6 @@
     "type": "git",
     "url": "https://github.com/Stuk/jszip"
   },
-  "licenses": [
-    "MIT",
-    "GPL-3.0"
-  ],
-  "author": "Stuart Knightley <stuart@stuartk.com>"
+  "author": "Stuart Knightley <stuart@stuartk.com>",
+  "license": "(MIT OR GPL-3.0)"
 }

--- a/packages/j/jvectormap.json
+++ b/packages/j/jvectormap.json
@@ -14,16 +14,7 @@
     "name": "Kirill Lebedev",
     "email": "echo.bjornd@gmail.com"
   },
-  "licenses": [
-    {
-      "type": "AGPL",
-      "url": "http://www.gnu.org/copyleft/gpl.html"
-    },
-    {
-      "type": "Commercial",
-      "url": "http://www.binpress.com/license/read/id/3085/app/2122"
-    }
-  ],
+  "license": "(AGPL OR Commercial)",
   "homepage": "http://jvectormap.com",
   "autoupdate": {
     "source": "git",

--- a/packages/l/livequery.json
+++ b/packages/l/livequery.json
@@ -22,10 +22,6 @@
     "name": "Brandon Aaron",
     "url": "http://brandon.aaron.sh"
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ],
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/brandonaaron/livequery.git",
@@ -37,5 +33,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/m/MaterialDesign-Webfont.json
+++ b/packages/m/MaterialDesign-Webfont.json
@@ -16,10 +16,6 @@
     "name": "Austin Andrews",
     "web": "http://twitter.com/templarian"
   },
-  "licenses": [
-    "OFL-1.1",
-    "MIT"
-  ],
   "homepage": "http://materialdesignicons.com",
   "autoupdate": {
     "source": "git",
@@ -32,5 +28,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(OFL-1.1 OR MIT)"
 }

--- a/packages/m/miniTip.json
+++ b/packages/m/miniTip.json
@@ -12,10 +12,6 @@
     "name": "James Simpson",
     "url": "http://goldfirestudios.com"
   },
-  "licenses": [
-    "MIT",
-    "GPL"
-  ],
   "homepage": "http://goldfirestudios.com/blog/81/miniTip-jQuery-Plugin",
   "repository": {
     "type": "git",
@@ -32,5 +28,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL)"
 }

--- a/packages/m/mixitup.json
+++ b/packages/m/mixitup.json
@@ -23,13 +23,7 @@
       }
     ]
   },
-  "licenses": [
-    "CC-BY-ND-3.0",
-    {
-      "type": "Commercial License",
-      "url": "https://www.kunkalabs.com/mixitup/licenses/"
-    }
-  ],
+  "license": "(CC-BY-ND-3.0 OR Commercial License)",
   "repository": {
     "type": "git",
     "url": "https://github.com/patrickkunka/mixitup"

--- a/packages/m/mobilizejs.json
+++ b/packages/m/mobilizejs.json
@@ -11,8 +11,5 @@
     "type": "git",
     "url": "https://github.com/mobilizejs/mobilize.js.git"
   },
-  "license": {
-    "type": "Creative Commons",
-    "url": "http://mobilizejs.com/documentation/"
-  }
+  "license": "Creative Commons"
 }

--- a/packages/n/Nestable.json
+++ b/packages/n/Nestable.json
@@ -19,8 +19,5 @@
     "type": "git",
     "url": "git://github.com/blueimp/JavaScript-Load-Image.git"
   },
-  "licenses": [
-    "MIT",
-    "BSD"
-  ]
+  "license": "(MIT OR BSD)"
 }

--- a/packages/o/open-iconic.json
+++ b/packages/o/open-iconic.json
@@ -22,10 +22,6 @@
     "type": "git",
     "url": "https://github.com/iconic/open-iconic.git"
   },
-  "licenses": [
-    "MIT",
-    "OFL-1.1"
-  ],
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/iconic/open-iconic.git",
@@ -41,5 +37,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR OFL-1.1)"
 }

--- a/packages/o/overpass.json
+++ b/packages/o/overpass.json
@@ -11,10 +11,6 @@
     "type": "git",
     "url": "https://github.com/RedHatBrand/Overpass"
   },
-  "licenses": [
-    "LGPL-2.1",
-    "OFL-1.1"
-  ],
   "author": "Red Hat Brand Team <@RedHatBrand> (https://brand.redhat.com/)",
   "autoupdate": {
     "source": "git",
@@ -27,5 +23,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(LGPL-2.1 OR OFL-1.1)"
 }

--- a/packages/p/paymentfont.json
+++ b/packages/p/paymentfont.json
@@ -25,9 +25,5 @@
     "type": "git",
     "url": "git://github.com/vendocrat/PaymentFont.git"
   },
-  "licenses": [
-    "OFL-1.1",
-    "MIT",
-    "CC-BY-3.0"
-  ]
+  "license": "(OFL-1.1 OR MIT OR CC-BY-3.0)"
 }

--- a/packages/p/pie.json
+++ b/packages/p/pie.json
@@ -11,12 +11,9 @@
     "css3",
     "pie"
   ],
-  "licenses": [
-    "Apache-2.0",
-    "GPL-2.0"
-  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/lojjic/PIE"
-  }
+  },
+  "license": "(Apache-2.0 OR GPL-2.0)"
 }

--- a/packages/p/pikaday.json
+++ b/packages/p/pikaday.json
@@ -8,10 +8,6 @@
     "date"
   ],
   "homepage": "http://dbushell.github.io/Pikaday/",
-  "licenses": [
-    "BSD",
-    "MIT"
-  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/dbushell/Pikaday.git"
@@ -28,5 +24,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(BSD OR MIT)"
 }

--- a/packages/p/placeholder-shiv.json
+++ b/packages/p/placeholder-shiv.json
@@ -10,8 +10,5 @@
     "type": "git",
     "url": "https://github.com/walterdavis/placeholder-shiv.git"
   },
-  "license": {
-    "type": "BSD-3-Clause",
-    "url": "https://github.com/walterdavis/placeholder-shiv/blob/master/LICENSE.txt"
-  }
+  "license": "BSD-3-Clause"
 }

--- a/packages/p/plupload.json
+++ b/packages/p/plupload.json
@@ -12,21 +12,7 @@
     "cross-browser",
     "upload"
   ],
-  "licenses": [
-    "GPL-2.0",
-    {
-      "type": "Single Website",
-      "url": "http://plupload.com/license/plupload_commercial_single.txt"
-    },
-    {
-      "type": "OEM",
-      "url": "http://plupload.com/license/plupload_commercial_oem.txt"
-    },
-    {
-      "type": "Custom Licensing",
-      "url": "http://www.moxiecode.com/contact.php"
-    }
-  ],
+  "license": "(GPL-2.0 OR Single Website OR OEM OR Custom Licensing)",
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/moxiecode/plupload.git",

--- a/packages/p/poshytip.json
+++ b/packages/p/poshytip.json
@@ -26,8 +26,5 @@
       }
     ]
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ]
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/p/prettyPhoto.json
+++ b/packages/p/prettyPhoto.json
@@ -11,10 +11,6 @@
     "YouTube",
     "iFrame"
   ],
-  "licenses": [
-    "CC-BY-2.5",
-    "GPL-2.0"
-  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/scaron/prettyphoto"
@@ -32,5 +28,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(CC-BY-2.5 OR GPL-2.0)"
 }

--- a/packages/p/pwstrength-bootstrap.json
+++ b/packages/p/pwstrength-bootstrap.json
@@ -15,10 +15,6 @@
     "type": "git",
     "url": "https://github.com/ablanco/jquery.pwstrength.bootstrap.git"
   },
-  "licenses": [
-    "GPL-3.0",
-    "MIT"
-  ],
   "autoupdate": {
     "source": "npm",
     "target": "pwstrength-bootstrap",
@@ -30,5 +26,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(GPL-3.0 OR MIT)"
 }

--- a/packages/q/qoopido.demand.json
+++ b/packages/q/qoopido.demand.json
@@ -29,10 +29,6 @@
     "type": "git",
     "url": "https://github.com/dlueth/qoopido.demand"
   },
-  "licenses": [
-    "MIT",
-    "deprecated_GPL-3.0+"
-  ],
   "autoupdate": {
     "source": "npm",
     "target": "qoopido.demand",
@@ -44,5 +40,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR deprecated_GPL-3.0+)"
 }

--- a/packages/q/qoopido.js.json
+++ b/packages/q/qoopido.js.json
@@ -10,13 +10,7 @@
     "type": "git",
     "url": "git://github.com/dlueth/qoopido.js.git"
   },
-  "licenses": [
-    "MIT",
-    {
-      "type": "GPL",
-      "url": "http://www.gnu.org/copyleft/gpl.html"
-    }
-  ],
+  "license": "(MIT OR GPL)",
   "keywords": [
     "modular",
     "library",

--- a/packages/q/qooxdoo.json
+++ b/packages/q/qooxdoo.json
@@ -13,8 +13,5 @@
     "type": "git",
     "url": "https://github.com/qooxdoo/qooxdoo.git"
   },
-  "licenses": [
-    "LGPL-2.1",
-    "EPL-1.0"
-  ]
+  "license": "(LGPL-2.1 OR EPL-1.0)"
 }

--- a/packages/r/repo.js.json
+++ b/packages/r/repo.js.json
@@ -10,8 +10,5 @@
   "keywords": [
     "repo.js"
   ],
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ]
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/r/require-domReady.json
+++ b/packages/r/require-domReady.json
@@ -10,8 +10,5 @@
     "type": "git",
     "url": "https://github.com/requirejs/domReady"
   },
-  "licenses": [
-    "MIT",
-    "BSD-3-Clause"
-  ]
+  "license": "(MIT OR BSD-3-Clause)"
 }

--- a/packages/r/require-i18n.json
+++ b/packages/r/require-i18n.json
@@ -10,10 +10,6 @@
     "type": "git",
     "url": "https://github.com/requirejs/i18n"
   },
-  "licenses": [
-    "BSD",
-    "MIT"
-  ],
   "author": "jrburke <jrburke@gmail.com>",
   "autoupdate": {
     "source": "git",
@@ -26,5 +22,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(BSD OR MIT)"
 }

--- a/packages/r/require-text.json
+++ b/packages/r/require-text.json
@@ -10,8 +10,5 @@
     "type": "git",
     "url": "https://github.com/requirejs/text"
   },
-  "licenses": [
-    "MIT",
-    "BSD-3-Clause"
-  ]
+  "license": "(MIT OR BSD-3-Clause)"
 }

--- a/packages/r/rpg-awesome.json
+++ b/packages/r/rpg-awesome.json
@@ -13,10 +13,6 @@
     "css",
     "toolkit"
   ],
-  "licenses": [
-    "MIT",
-    "OFL-1.1"
-  ],
   "name": "rpg-awesome",
   "repository": {
     "type": "git",
@@ -34,5 +30,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR OFL-1.1)"
 }

--- a/packages/s/ScrollMagic.json
+++ b/packages/s/ScrollMagic.json
@@ -6,10 +6,6 @@
     "name": "Jan Paepke",
     "url": "http://www.janpaepke.de"
   },
-  "licenses": [
-    "MIT",
-    "GPL-3.0+"
-  ],
   "homepage": "http://janpaepke.github.io/ScrollMagic/",
   "keywords": [
     "scroll",
@@ -49,5 +45,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-3.0+)"
 }

--- a/packages/s/Swiper.json
+++ b/packages/s/Swiper.json
@@ -12,10 +12,6 @@
   ],
   "author": "Vladimir Kharlampidi",
   "homepage": "http://www.idangero.us/sliders/swiper",
-  "licenses": [
-    "GPL",
-    "MIT"
-  ],
   "autoupdate": {
     "source": "npm",
     "target": "swiper",
@@ -28,5 +24,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(GPL OR MIT)"
 }

--- a/packages/s/shoestring.json
+++ b/packages/s/shoestring.json
@@ -11,10 +11,6 @@
     "email": "thegroup@filamentgroup.com",
     "url": "filamentgroup.com"
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ],
   "keywords": [
     "lightweight",
     "DOM-ready",
@@ -32,5 +28,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/s/sjcl.json
+++ b/packages/s/sjcl.json
@@ -3,10 +3,6 @@
   "filename": "sjcl.min.js",
   "description": "Stanford Javascript Crypto Library",
   "author": "bitwiseshiftleft",
-  "licenses": [
-    "GPL-2.0",
-    "BSD-2-Clause"
-  ],
   "keywords": [
     "encryption",
     "high-level",
@@ -27,5 +23,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(GPL-2.0 OR BSD-2-Clause)"
 }

--- a/packages/s/slabText.json
+++ b/packages/s/slabText.json
@@ -14,8 +14,5 @@
     "type": "git",
     "url": "https://github.com/freqdec/slabText"
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ]
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/t/TypeWatch.json
+++ b/packages/t/TypeWatch.json
@@ -18,10 +18,6 @@
     "autocomplete",
     "jquery"
   ],
-  "licenses": [
-    "MIT",
-    "GPL-3.0"
-  ],
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/dennyferra/TypeWatch.git",
@@ -33,5 +29,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR GPL-3.0)"
 }

--- a/packages/t/taggd.json
+++ b/packages/t/taggd.json
@@ -11,10 +11,6 @@
     "email": "timseverien@gmail.com",
     "url": "https://timseverien.com"
   },
-  "licenses": [
-    "MIT",
-    "WTFPL"
-  ],
   "homepage": "https://timseverien.github.io/taggd/",
   "keywords": [
     "jQuery",
@@ -32,5 +28,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(MIT OR WTFPL)"
 }

--- a/packages/t/timedropper.json
+++ b/packages/t/timedropper.json
@@ -12,8 +12,5 @@
   ],
   "author": "Felice Gattuso",
   "homepage": "http://felicegattuso.com/projects/timedropper/",
-  "licenses": [
-    "MIT",
-    "CC-BY-4.0"
-  ]
+  "license": "(MIT OR CC-BY-4.0)"
 }

--- a/packages/t/timepicker.json
+++ b/packages/t/timepicker.json
@@ -24,10 +24,6 @@
       }
     ]
   },
-  "licenses": [
-    "MIT",
-    "GPL"
-  ],
   "keywords": [
     "timepicker",
     "time",
@@ -36,5 +32,6 @@
     "dropdown",
     "input",
     "form"
-  ]
+  ],
+  "license": "(MIT OR GPL)"
 }

--- a/packages/t/treesaver.json
+++ b/packages/t/treesaver.json
@@ -10,8 +10,5 @@
     "type": "git",
     "url": "https://github.com/Treesaver/treesaver"
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ]
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/t/tv4.json
+++ b/packages/t/tv4.json
@@ -14,13 +14,7 @@
     "url": "git+https://github.com/geraintluff/tv4.git"
   },
   "homepage": "https://geraintluff.github.io/tv4/",
-  "licenses": [
-    {
-      "type": "Public Domain",
-      "url": "http://geraintluff.github.io/tv4/LICENSE.txt"
-    },
-    "MIT"
-  ],
+  "license": "(Public Domain OR MIT)",
   "autoupdate": {
     "source": "npm",
     "target": "tv4",

--- a/packages/t/twemoji.json
+++ b/packages/t/twemoji.json
@@ -16,10 +16,6 @@
     "name": "Twitter, Inc.",
     "url": "https://github.com/twitter/"
   },
-  "licenses": [
-    "MIT",
-    "CC-BY-4.0"
-  ],
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/twitter/twemoji.git",
@@ -42,5 +38,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/twitter/twemoji.git"
-  }
+  },
+  "license": "(MIT OR CC-BY-4.0)"
 }

--- a/packages/u/UAParser.js.json
+++ b/packages/u/UAParser.js.json
@@ -11,10 +11,6 @@
     "device",
     "cpu"
   ],
-  "licenses": [
-    "GPL-2.0",
-    "MIT"
-  ],
   "author": "Faisal Salman <fyzlman@gmail.com> (http://faisalman.com)",
   "repository": {
     "type": "git",
@@ -31,5 +27,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(GPL-2.0 OR MIT)"
 }

--- a/packages/u/ui.multiselect.json
+++ b/packages/u/ui.multiselect.json
@@ -28,8 +28,5 @@
       }
     ]
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ]
+  "license": "(MIT OR GPL-2.0)"
 }

--- a/packages/u/unsemantic.json
+++ b/packages/u/unsemantic.json
@@ -25,9 +25,6 @@
     "type": "git",
     "url": "https://github.com/nathansmith/unsemantic/"
   },
-  "licenses": [
-    "GPL",
-    "MIT"
-  ],
-  "author": "Nathan Smith"
+  "author": "Nathan Smith",
+  "license": "(GPL OR MIT)"
 }

--- a/packages/v/vertx.json
+++ b/packages/v/vertx.json
@@ -3,10 +3,6 @@
   "filename": "vertx-eventbus.min.js",
   "description": "Effortless asynchronous application development for the modern web and enterprise. This library internally uses SockJS to send and receive data to a SockJS vert.x server called the SockJS bridge. http://vertx.io/core_manual_js.html#sockjs-eventbus-bridge",
   "homepage": "http://vertx.io/",
-  "licenses": [
-    "EPL-1.0",
-    "Apache-2.0"
-  ],
   "keywords": [
     "vertx",
     "vert.x",
@@ -29,5 +25,6 @@
         ]
       }
     ]
-  }
+  },
+  "license": "(EPL-1.0 OR Apache-2.0)"
 }

--- a/packages/v/vis.json
+++ b/packages/v/vis.json
@@ -32,8 +32,5 @@
       }
     ]
   },
-  "licenses": [
-    "Apache-2.0",
-    "MIT"
-  ]
+  "license": "(Apache-2.0 OR MIT)"
 }

--- a/packages/w/winstrap.json
+++ b/packages/w/winstrap.json
@@ -2,10 +2,6 @@
   "name": "winstrap",
   "filename": "css/winstrap.min.css",
   "description": "Winstrap is the official Bootstrap theme for Microsoft design language.",
-  "licenses": [
-    "MIT",
-    "OFL-1.1"
-  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/winjs/winstrap.git"
@@ -29,5 +25,6 @@
       }
     ]
   },
-  "author": "Microsoft"
+  "author": "Microsoft",
+  "license": "(MIT OR OFL-1.1)"
 }

--- a/packages/z/zingchart.json
+++ b/packages/z/zingchart.json
@@ -17,10 +17,7 @@
   "author": {
     "name": "ZingChart"
   },
-  "license": {
-    "name": "ZingChart Branded License",
-    "url": "https://www.zingchart.com/buy/details/branded-license/"
-  },
+  "license": "ZingChart Branded License",
   "autoupdate": {
     "source": "npm",
     "target": "zingchart",

--- a/packages/z/zoomooz.json
+++ b/packages/z/zoomooz.json
@@ -18,10 +18,6 @@
     "email": "janne@aukia.com",
     "url": "https://github.com/jaukia"
   },
-  "licenses": [
-    "MIT",
-    "GPL-2.0"
-  ],
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/jaukia/zoomooz.git",
@@ -37,5 +33,6 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/jaukia/zoomooz.git"
-  }
+  },
+  "license": "(MIT OR GPL-2.0)"
 }


### PR DESCRIPTION
No more `licenses` field, just `license`. [For reference](https://docs.npmjs.com/files/package.json#license).

Will update the CI to enforce `license` in another PR, as well as find any stragglers that haven't been fixed....

```
find -name '*.json' | xargs -n 1 -P 10 -I {} bash -c 'jq "if .license.name then . + {license: .license.name} else . end" "{}" > "{}.tmp" && mv "{}.tmp" "{}"'

find -name '*.json' | xargs -n 1 -P 10 -I {} bash -c 'jq "if .license.type then . + {license: .license.type} else . end" "{}" > "{}.tmp" && mv "{}.tmp" "{}"'

find -name '*.json' | xargs -n 1 -P 10 -I {} bash -c 'jq "if .licenses then . + {license: (\"(\"+(.licenses | join(\" OR \"))+\")\")} | del(.licenses) else . end" "{}" > "{}.tmp" && mv "{}.tmp" "{}"'
```

Credit to @klausenbusk . I tweaked your command from before 😉 