### PR TITLE
Standardize Respository field

### DIFF
--- a/packages/a/airbrake-browser.json
+++ b/packages/a/airbrake-browser.json
@@ -12,8 +12,7 @@
   "homepage": "https://github.com/airbrake/airbrake-js/tree/master/packages/browser",
   "repository": {
     "type": "git",
-    "url": "git://github.com/airbrake/airbrake-js.git",
-    "directory": "packages/browser"
+    "url": "git://github.com/airbrake/airbrake-js.git"
   },
   "autoupdate": {
     "source": "npm",

--- a/packages/a/angular.json
+++ b/packages/a/angular.json
@@ -17,8 +17,7 @@
   "homepage": "https://github.com/angular/angular#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/angular/angular.git",
-    "directory": "packages/core"
+    "url": "git+https://github.com/angular/angular.git"
   },
   "filename": "core.umd.min.js",
   "autoupdate": {

--- a/packages/d/datejs.json
+++ b/packages/d/datejs.json
@@ -10,7 +10,7 @@
     "parser"
   ],
   "repository": {
-    "type": "Google SVN",
+    "type": "svn",
     "url": "http://code.google.com/p/datejs/source"
   },
   "license": "Apache-2.0"

--- a/packages/j/js-url.json
+++ b/packages/j/js-url.json
@@ -21,7 +21,7 @@
     ]
   },
   "repository": {
-    "type": "github",
+    "type": "git",
     "url": "https://github.com/websanova/js-url"
   },
   "author": {

--- a/packages/m/material-ui.json
+++ b/packages/m/material-ui.json
@@ -12,7 +12,6 @@
   "license": "MIT",
   "name": "material-ui",
   "repository": {
-    "directory": "packages/material-ui",
     "type": "git",
     "url": "git+https://github.com/mui-org/material-ui.git"
   },

--- a/packages/n/ninjaui.json
+++ b/packages/n/ninjaui.json
@@ -9,7 +9,7 @@
     "jquery"
   ],
   "repository": {
-    "type": "plain file",
+    "type": "git",
     "url": "https://github.com/ninja/ui/"
   },
   "authors": [

--- a/packages/o/openajax-hub.json
+++ b/packages/o/openajax-hub.json
@@ -14,8 +14,7 @@
   ],
   "repository": {
     "type": "svn",
-    "url": "https://openajaxallianc.svn.sourceforge.net/svnroot/openajaxallianc",
-    "path": "hub20/trunk/src/OpenAjax.js"
+    "url": "https://openajaxallianc.svn.sourceforge.net/svnroot/openajaxallianc"
   },
   "license": "Apache-2.0"
 }

--- a/packages/p/photoset-grid.json
+++ b/packages/p/photoset-grid.json
@@ -9,8 +9,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/stylehatch/photoset-grid.git",
-    "docs": "http://stylehatch.github.com/photoset-grid/"
+    "url": "git://github.com/stylehatch/photoset-grid.git"
   },
   "autoupdate": {
     "source": "git",

--- a/packages/p/piecon.json
+++ b/packages/p/piecon.json
@@ -22,7 +22,7 @@
     ]
   },
   "repository": {
-    "type": "github",
+    "type": "git",
     "url": "https://github.com/lipka/piecon"
   },
   "license": "MIT",

--- a/packages/r/react-is.json
+++ b/packages/r/react-is.json
@@ -10,7 +10,6 @@
   "name": "react-is",
   "namespace": "React",
   "repository": {
-    "directory": "packages/react-is",
     "type": "git",
     "url": "git+https://github.com/facebook/react.git"
   },

--- a/packages/s/screenfull.js.json
+++ b/packages/s/screenfull.js.json
@@ -20,7 +20,7 @@
     ]
   },
   "repository": {
-    "type": "github",
+    "type": "git",
     "url": "https://github.com/sindresorhus/screenfull.js"
   },
   "license": "MIT"

--- a/packages/t/tinycon.json
+++ b/packages/t/tinycon.json
@@ -21,7 +21,7 @@
     ]
   },
   "repository": {
-    "type": "github",
+    "type": "git",
     "url": "https://github.com/tommoor/tinycon"
   },
   "author": "Tom Moor <tom.moor@gmail.com> (http://tommoor.com)",

--- a/packages/t/toxiclibsjs.json
+++ b/packages/t/toxiclibsjs.json
@@ -9,7 +9,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://raw.github.com/hapticdata/toxiclibsjs/master/build/toxiclibs.min.js"
+    "url": "https://github.com/hapticdata/toxiclibsjs"
   },
   "license": "LGPL-2.1"
 }

--- a/packages/t/toxiclibsjs.json
+++ b/packages/t/toxiclibsjs.json
@@ -8,7 +8,7 @@
     "processing"
   ],
   "repository": {
-    "type": "plain file",
+    "type": "git",
     "url": "https://raw.github.com/hapticdata/toxiclibsjs/master/build/toxiclibs.min.js"
   },
   "license": "LGPL-2.1"


### PR DESCRIPTION
- remove path attribute from legacy package'

All current `repository` attributes:

```
Summary of Keys in Object
repository: KEYS (3897): type
repository: KEYS (3897): url
repository: KEYS (4): directory
repository: [a/airbrake-browser.json a/angular.json m/material-ui.json r/react-is.json]

repository: KEYS (1): path
repository: [o/openajax-hub.json]

repository: KEYS (1): docs
repository: [p/photoset-grid.json]
```