### PR TITLE
Standardize filename field

### DIFF
--- a/packages/m/mavo.json
+++ b/packages/m/mavo.json
@@ -1,7 +1,7 @@
 {
   "name": "mavo",
   "description": "Create web applications with HTML and CSS",
-  "main": "mavo.js",
+  "filename": "mavo.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/mavoweb/mavo.git"

--- a/packages/m/mavo.json
+++ b/packages/m/mavo.json
@@ -1,7 +1,7 @@
 {
   "name": "mavo",
   "description": "Create web applications with HTML and CSS",
-  "filename": "mavo.js",
+  "filename": "mavo.min.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/mavoweb/mavo.git"


### PR DESCRIPTION
[mavo](https://github.com/cdnjs/cdnjs/tree/master/ajax/libs/mavo) has `main` instead of `filename`. This is the only package with top-level property `main`.