### PR TITLE
Add map files to list of retrieved files

### DIFF
--- a/packages/t/twitter-bootstrap.json
+++ b/packages/t/twitter-bootstrap.json
@@ -26,7 +26,7 @@
       {
         "basePath": "dist",
         "files": [
-          "**/*.@(js|css)"
+          "**/*.@(js|css|map)"
         ]
       },
       {


### PR DESCRIPTION
The `.map` files are missing from the bootstrap 4.5.1 and 4.5.2 releases and causes console warnings as a result. However, looking at the diffs for the last few versions, I can't see a reason why they would have gone missing.

This change _should_ ensure they're being pulled in for future releases.