### PR TITLE
Update limonte-sweetalert2 w/ npm auto-update

### DIFF
--- a/packages/l/limonte-sweetalert2.json
+++ b/packages/l/limonte-sweetalert2.json
@@ -16,13 +16,13 @@
     "prompt"
   ],
   "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/sweetalert2/sweetalert2.git",
+    "source": "npm",
+    "target": "sweetalert2",
     "fileMap": [
       {
         "basePath": "dist",
         "files": [
-          "**/!(*.gz)"
+          "**/*.@(js|css)"
         ]
       }
     ]


### PR DESCRIPTION
At some point `dist` was removed from the repo, so switch to the `dist` from the `npm` package.

Refs #302 