### PR TITLE
Update sip.js w/ npm auto-update

### DIFF
--- a/packages/s/sip.js.json
+++ b/packages/s/sip.js.json
@@ -15,13 +15,13 @@
     "type": "git",
     "url": "git+https://github.com/onsip/SIP.js.git"
   },
-  "filename": "index.js",
+  "filename": "sip.min.js",
   "autoupdate": {
-    "source": "npm",
-    "target": "sip.js",
+    "source": "git",
+    "target": "git://github.com/onsip/SIP.js.git",
     "fileMap": [
       {
-        "basePath": "lib",
+        "basePath": "dist",
         "files": [
           "*.js"
         ]

--- a/packages/s/sip.js.json
+++ b/packages/s/sip.js.json
@@ -15,13 +15,13 @@
     "type": "git",
     "url": "git+https://github.com/onsip/SIP.js.git"
   },
-  "filename": "sip.min.js",
+  "filename": "index.js",
   "autoupdate": {
     "source": "npm",
     "target": "sip.js",
     "fileMap": [
       {
-        "basePath": "dist",
+        "basePath": "lib",
         "files": [
           "*.js"
         ]


### PR DESCRIPTION
We've updated our dist folder from `dist` to `lib` since moving to typescript, and the initial file to pull is now `index.js` there instead of `sip.min.js`