### PR TITLE
Update nipplejs w/ npm auto-update

### DIFF
--- a/packages/n/nipplejs.json
+++ b/packages/n/nipplejs.json
@@ -20,7 +20,7 @@
       {
         "basePath": "dist",
         "files": [
-          "nipple.js"
+          "**/*"
         ]
       }
     ]

--- a/packages/n/nipplejs.json
+++ b/packages/n/nipplejs.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/yoannmoinet/nipplejs.git"
   },
-  "homepage": "https://yoannmoinet.github.io/nipplejs",
+  "homepage": "https://yoannmoi.net/nipplejs",
   "keywords": [
     "virtual",
     "joystick",
@@ -28,7 +28,7 @@
   "authors": [
     {
       "name": "Yoann Moinet",
-      "email": "yoann.moinet@gmail.com"
+      "email": "yo@nnmoi.net"
     }
   ]
 }

--- a/packages/n/nipplejs.json
+++ b/packages/n/nipplejs.json
@@ -1,6 +1,6 @@
 {
   "name": "nipplejs",
-  "filename": "nipplejs.min.js",
+  "filename": "nipplejs.js",
   "description": "A virtual joystick for touch capable interfaces",
   "license": "MIT",
   "repository": {

--- a/packages/n/nipplejs.json
+++ b/packages/n/nipplejs.json
@@ -14,13 +14,13 @@
     "touch"
   ],
   "autoupdate": {
-    "source": "git",
-    "target": "https://github.com/yoannmoinet/nipplejs.git",
+    "source": "npm",
+    "target": "nipplejs",
     "fileMap": [
       {
         "basePath": "dist",
         "files": [
-          "**/*"
+          "nipple.js"
         ]
       }
     ]

--- a/packages/n/nipplejs.json
+++ b/packages/n/nipplejs.json
@@ -20,7 +20,7 @@
       {
         "basePath": "dist",
         "files": [
-          "**/*"
+          "*.js"
         ]
       }
     ]


### PR DESCRIPTION
We've updated our way of delivering the lib.
We don't ship built files anymore, they are built in the prepack script instead.

This PR reflects this change.