### PR TITLE
Add fasy w/ npm auto-update

### DIFF
--- a/packages/f/fasy.json
+++ b/packages/f/fasy.json
@@ -1,0 +1,35 @@
+{
+  "name": "fasy",
+  "description": "FP iterator helpers that are async/generator aware",
+  "filename": "umd/bundle.js",
+  "keywords": [
+    "fp",
+    "functional programming",
+    "async"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/getify/fasy.git"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/getify/fasy",
+  "autoupdate": {
+    "source": "npm",
+    "target": "fasy",
+    "fileMap": [
+      {
+        "basePath": "dist",
+        "files": [
+          "umd/*.?(js|json|map)",
+          "esm/*.?(js|mjs|json|map)"
+        ]
+      }
+    ]
+  },
+  "authors": [
+    {
+      "name": "Kyle Simpson",
+      "email": "getify@gmail.com"
+    }
+  ]
+}


### PR DESCRIPTION
Library name: fasy
Git repository url: https://github.com/getify/fasy
npm package name or url (if there is one) : fasy
License (List them all if it's multiple): MIT
Official homepage: https://github.com/getify/fasy