### PR TITLE
Update echarts w/ npm auto-update

### DIFF
--- a/packages/e/echarts.json
+++ b/packages/e/echarts.json
@@ -10,8 +10,8 @@
     "data visualization"
   ],
   "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/apache/incubator-echarts.git",
+    "source": "npm",
+    "target": "echarts",
     "fileMap": [
       {
         "basePath": "dist",


### PR DESCRIPTION
Hi, dear cdnjs team,

The releases in GitHub of ECharts include the release candidate versions, which may bring a lack of formal version, for example, previously, the bot just remained the `4.9.0-rc.1` but not remained the formal version `4.9.0` because of the same commit.

So I'd like to suggest changing the source to npm. Can it avoid this issue?

Thanks.