### PR TITLE
Add deepstream-client w/ npm auto-update

### DIFF
--- a/packages/d/deepstream-client.json
+++ b/packages/d/deepstream-client.json
@@ -1,0 +1,34 @@
+{
+  "name": "deepstream-client",
+  "description": "the javascript client for deepstream.io",
+  "keywords": [
+    "deepstream",
+    "javascript",
+    "realtime",
+    "client"
+  ],
+  "license": "MIT",
+  "homepage": "http://deepstream.io",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/deepstreamIO/deepstream.io-client-js.git"
+  },
+  "authors": [
+    {
+      "name": "deepstreamHub GmbH"
+    }
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "@deepstream/client",
+    "fileMap": [
+      {
+        "basePath": "dist/bundle",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "ds.min.js"
+}


### PR DESCRIPTION
Adding deepstream-client using npm auto-update from @deepstream/client.

Resolves #523.