### PR TITLE
Add chartjs-plugin-datalabels w/ npm auto-update

### DIFF
--- a/packages/c/chartjs-plugin-datalabels.json
+++ b/packages/c/chartjs-plugin-datalabels.json
@@ -1,0 +1,29 @@
+{
+  "name": "chartjs-plugin-datalabels",
+  "description": "Chart.js plugin to display labels on data elements",
+  "keywords": [
+    "chart.js",
+    "plugin",
+    "label"
+  ],
+  "license": "MIT",
+  "homepage": "https://chartjs-plugin-datalabels.netlify.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chartjs/chartjs-plugin-datalabels.git"
+  },
+  "authors": [],
+  "autoupdate": {
+    "source": "npm",
+    "target": "chartjs-plugin-datalabels",
+    "fileMap": [
+      {
+        "basePath": "dist",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "chartjs-plugin-datalabels.min.js"
+}

--- a/packages/c/chartjs-plugin-datalabels.json
+++ b/packages/c/chartjs-plugin-datalabels.json
@@ -12,7 +12,12 @@
     "type": "git",
     "url": "git+https://github.com/chartjs/chartjs-plugin-datalabels.git"
   },
-  "authors": [],
+  "authors": [
+    {
+      "name": "Simon Brunel",
+      "url": "https://github.com/simonbrunel"
+    }
+  ],
   "autoupdate": {
     "source": "npm",
     "target": "chartjs-plugin-datalabels",


### PR DESCRIPTION
Adding chartjs-plugin-datalabels using npm auto-update from chartjs-plugin-datalabels.

Resolves #538.