### PR TITLE
Add cldr-json w/ git auto-update

### DIFF
--- a/packages/c/cldr-json.json
+++ b/packages/c/cldr-json.json
@@ -1,7 +1,10 @@
 {
   "name": "cldr-json",
   "description": "JSON Data from the Unicode CLDR Project",
-  "keywords": [],
+  "keywords": [
+    "unicode",
+    "cldr"
+  ],
   "license": "NOASSERTION",
   "homepage": "https://github.com/unicode-org/cldr-json#bug-reports",
   "repository": {

--- a/packages/c/cldr-json.json
+++ b/packages/c/cldr-json.json
@@ -1,0 +1,28 @@
+{
+  "name": "cldr-json",
+  "description": "JSON Data from the Unicode CLDR Project",
+  "keywords": [],
+  "license": "NOASSERTION",
+  "homepage": "https://github.com/unicode-org/cldr-json#bug-reports",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/unicode-org/cldr-json.git"
+  },
+  "authors": [
+    {
+      "name": "unicode-org"
+    }
+  ],
+  "autoupdate": {
+    "source": "git",
+    "target": "git://github.com/unicode-org/cldr-json.git",
+    "fileMap": [
+      {
+        "basePath": "cldr-json",
+        "files": [
+          "**/!(package|bower).json"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adding cldr-json using git auto-update from git://github.com/unicode-org/cldr-json.git.

Resolves #258.