### PR TITLE
Update simple-statistics w/ npm auto-update

### DIFF
--- a/packages/s/simple-statistics.json
+++ b/packages/s/simple-statistics.json
@@ -14,7 +14,7 @@
     "linear",
     "bayesian"
   ],
-  "filename": "simple_statistics.min.js",
+  "filename": "simple-statistics.min.js",
   "license": "ISC",
   "autoupdate": {
     "source": "npm",
@@ -23,8 +23,7 @@
       {
         "basePath": "dist",
         "files": [
-          "simple_statistics.min.js",
-          "simple_statistics.js"
+          "**/*"
         ]
       }
     ]

--- a/packages/s/simple-statistics.json
+++ b/packages/s/simple-statistics.json
@@ -23,7 +23,7 @@
       {
         "basePath": "dist",
         "files": [
-          "**/*"
+          "*.@(js|mjs)?(.map)"
         ]
       }
     ]


### PR DESCRIPTION
Recent versions of simple-statistics produce files with the base name `simple-statistics` instead of `simple_statistics`, I believe that is why no recent versions are available on cdnjs.

I am not sure what the meaning of the `"filename"` field is, and whether updating it to match the filenames and the library name will break anything.

Similarly, I don't know if this change will magically add all missing versions of the library to cdnjs.

Refs: https://github.com/simple-statistics/simple-statistics/commit/b7045c21fb24345267338fabf6d944b47e25575c
Fixes: https://github.com/simple-statistics/simple-statistics/issues/536