### PR TITLE
Update rita.json

### DIFF
--- a/packages/r/rita.json
+++ b/packages/r/rita.json
@@ -1,32 +1,30 @@
 {
   "name": "rita",
-  "description": "RiTa: A toolkit for natural language and computational literature",
+  "description": "RiTa: A toolkit for generative natural language",
   "homepage": "https://rednoise.org/rita",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dhowe/RiTaJS.git"
+    "url": "https://github.com/dhowe/ritajs.git"
   },
   "keywords": [
-    "nlp",
-    "natural language",
-    "language",
-    "writing",
-    "generative"
+   "natural language",
+    "generative text",
+    "text analysis"
   ],
   "license": "GPL-3.0",
   "autoupdate": {
     "source": "git",
-    "target": "git://github.com/dhowe/RiTaJS.git",
+    "target": "git://github.com/dhowe/ritajs.git",
     "fileMap": [
       {
         "basePath": "dist",
         "files": [
-          "**/*"
+          "**/*.js"
         ]
       }
     ]
   },
-  "filename": "rita.min.js",
+  "filename": "rita-web.js",
   "authors": [
     {
       "name": "Daniel C. Howe",


### PR DESCRIPTION
Trying to get this library to update on cdnjs. It seems to be stuck on 1.3.94 while the current version is 2.0.20. Perhaps a case-sensitivity issue with the github repo name