### PR TITLE
Update playcanvas w/ npm auto-update

### DIFF
--- a/packages/p/playcanvas.json
+++ b/packages/p/playcanvas.json
@@ -25,7 +25,7 @@
     "target": "playcanvas",
     "fileMap": [
       {
-        "basePath": "build/output",
+        "basePath": "build",
         "files": [
           "*.@(js|ts)"
         ]


### PR DESCRIPTION
The build folder for PlayCanvas recently changed from `build/output` to just `build`. This PR fixes the mismatch.