### PR TITLE
Update jclic.js w/ npm auto-update

### DIFF
--- a/packages/j/jclic.js.json
+++ b/packages/j/jclic.js.json
@@ -21,13 +21,13 @@
   ],
   "license": "EUPL-1.1",
   "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/projectestac/jclic.js.git",
+    "source": "npm",
+    "target": "jclic",
     "fileMap": [
       {
         "basePath": "dist",
         "files": [
-          "**/!(*.LICENSE|*es6*)"
+          "*.js"
         ]
       }
     ]


### PR DESCRIPTION
Since the 'dist' folder is no longer included in the GitHub repository,
auto-update source must be changed to 'npm'.

Also, only '*.js' files are now included.