### PR TITLE
Mark fingerprintjs and fingerprintjs2 as renamed

### DIFF
--- a/packages/f/fingerprintjs.json
+++ b/packages/f/fingerprintjs.json
@@ -1,7 +1,7 @@
 {
   "name": "fingerprintjs",
   "filename": "fingerprint.min.js",
-  "description": "Fast browser fingerprint library. By default uses Murmur hashing and returns a 32bit integer number.",
+  "description": "The library has been renamed to @fingeprintjs/fingerprintjs. Check the link below to get updates.",
   "homepage": "https://github.com/valve/fingerprintjs/",
   "keywords": [
     "fingerprint"
@@ -11,6 +11,7 @@
     "url": "https://github.com/Valve/fingerprintjs"
   },
   "license": "MIT",
+  "homepage": "https://github.com/fingerprintjs/fingerprintjs",
   "autoupdate": {
     "source": "npm",
     "target": "fingerprintjs",

--- a/packages/f/fingerprintjs2.json
+++ b/packages/f/fingerprintjs2.json
@@ -1,7 +1,7 @@
 {
   "name": "fingerprintjs2",
   "filename": "fingerprint2.min.js",
-  "description": "Modern & flexible browser fingerprinting library",
+  "description": "The library has been renamed to @fingeprintjs/fingerprintjs. Check the link below to get updates.",
   "repository": {
     "type": "git",
     "url": "https://github.com/Valve/fingerprintjs2.git"
@@ -14,7 +14,7 @@
     "privacy"
   ],
   "license": "MIT",
-  "homepage": "https://valve.github.io/fingerprintjs2/",
+  "homepage": "https://github.com/fingerprintjs/fingerprintjs",
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/Valve/fingerprintjs2.git",


### PR DESCRIPTION
I'm a FingerpringJS maintainer. The libraries have been renamed to `@fingerprintjs/fingerprintjs` and I try to convince users to switch to the new name. You can open any old link in the configuration files to check that they all redirect to the new repository name.