### PR TITLE
Add reseter.css w/ npm auto-update

### DIFF
--- a/packages/r/reseter.css.json
+++ b/packages/r/reseter.css.json
@@ -20,7 +20,7 @@
       {
         "basePath": "",
         "files": [
-          "css/reseter.@(sass|scss|less|styl|ts|js|mjs)",          
+          "css/reseter.@(css|min.css)",          
           "src/**/reseter.@(sass|scss|less|styl|ts|js|mjs)" 
         ]
       }

--- a/packages/r/reseter.css.json
+++ b/packages/r/reseter.css.json
@@ -31,5 +31,5 @@
       }
     ]
   },
-  "filename": "css/reseter.min.css"
+  "filename": "reseter.min.css"
 }

--- a/packages/r/reseter.css.json
+++ b/packages/r/reseter.css.json
@@ -8,17 +8,8 @@
     "Reboot"
   ],
   "homepage": "https://krishdevdb.github.io/reseter.css/",
-  "bugs": {
-    "url": "https://github.com/krishdevdb/reseter.css/issues",
-    "email": "krishdevdb@gmail.com"
-  },
+  "repository": "github:krishdevdb/reseter.css",
   "license": "MIT",
-  "author": {
-    "name": "Krish",
-    "email": "krishdevdb@gmail.com",
-    "url": "https://github.com/krishdevdb/"
-  },
-  "contributors": [],
   "autoupdate": {
     "source": "npm",
     "target": "reseter.css",

--- a/packages/r/reseter.css.json
+++ b/packages/r/reseter.css.json
@@ -1,0 +1,24 @@
+  "autoupdate": {
+    "source": "npm",
+    "target": "reseter.css",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "src",
+        "files": [
+          "sass/*.sass",
+          "scss/*.scss",
+          "less/*.less",
+          "stylus/*.styl",
+          "styled-components/js/*.js",
+          "styled-components/js/*.mjs",
+          "styled-components/ts/*.ts"
+        ]
+      }
+    ]
+  }

--- a/packages/r/reseter.css.json
+++ b/packages/r/reseter.css.json
@@ -18,10 +18,15 @@
     "target": "reseter.css",
     "fileMap": [
       {
+        "basePath": "css",
+        "files": [
+          "*?(.min).css"
+        ]
+      },
+      {
         "basePath": "",
         "files": [
-          "css/reseter.@(css|min.css)",          
-          "src/**/reseter.@(sass|scss|less|styl|ts|js|mjs)" 
+          "src/**/reseter.@(sass|scss|less|styl|ts|js|mjs)"
         ]
       }
     ]

--- a/packages/r/reseter.css.json
+++ b/packages/r/reseter.css.json
@@ -8,7 +8,10 @@
     "Reboot"
   ],
   "homepage": "https://krishdevdb.github.io/reseter.css/",
-  "repository": "github:krishdevdb/reseter.css",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/krishdevdb/reseter.css.git"
+  },
   "license": "MIT",
   "autoupdate": {
     "source": "npm",

--- a/packages/r/reseter.css.json
+++ b/packages/r/reseter.css.json
@@ -20,7 +20,8 @@
       {
         "basePath": "",
         "files": [
-          "**/**/reseter.@(sass|scss|less|styl|ts|js|mjs)"
+          "css/reseter.@(sass|scss|less|styl|ts|js|mjs)",          
+          "src/**/reseter.@(sass|scss|less|styl|ts|js|mjs)" 
         ]
       }
     ]

--- a/packages/r/reseter.css.json
+++ b/packages/r/reseter.css.json
@@ -1,24 +1,35 @@
+{
+  "name": "reseter.css",
+  "description": "Reset All CSS By Browsers With Reseter.css. And Make Web Look Same Across All Browsers",
+  "keywords": [
+    "Reset.css",
+    "Normalize.css",
+    "Sanitize.css",
+    "Reboot"
+  ],
+  "homepage": "https://krishdevdb.github.io/reseter.css/",
+  "bugs": {
+    "url": "https://github.com/krishdevdb/reseter.css/issues",
+    "email": "krishdevdb@gmail.com"
+  },
+  "license": "MIT",
+  "author": {
+    "name": "Krish",
+    "email": "krishdevdb@gmail.com",
+    "url": "https://github.com/krishdevdb/"
+  },
+  "contributors": [],
   "autoupdate": {
     "source": "npm",
     "target": "reseter.css",
     "fileMap": [
       {
-        "basePath": "css",
+        "basePath": "",
         "files": [
-          "*.css"
-        ]
-      },
-      {
-        "basePath": "src",
-        "files": [
-          "sass/*.sass",
-          "scss/*.scss",
-          "less/*.less",
-          "stylus/*.styl",
-          "styled-components/js/*.js",
-          "styled-components/js/*.mjs",
-          "styled-components/ts/*.ts"
+          "**/**/reseter.@(sass|scss|less|styl|ts|js|mjs)"
         ]
       }
     ]
-  }
+  },
+  "filename": "css/reseter.min.css"
+}


### PR DESCRIPTION
Hi There I know that reseter.css's npm stats are a little low but its a new project about 1.5 months old and will take time to adopted by people but on some other platforms there are stats that comply to the requirement

> Pls keep in mind that the stats are yearly but the package is about 1.5 months old

JsDelivr GitHub CDN: ![jsDelivr hits (GitHub)](https://img.shields.io/jsdelivr/gh/hy/krishdevdb/reseter.css?style=flat-square)

JsDelivr NPM CDN: ![jsDelivr hits (npm)](https://img.shields.io/jsdelivr/npm/hy/reseter.css?style=flat-square)

NPM Downloads: ![npm](https://img.shields.io/npm/dy/reseter.css?style=flat-square)

GitHub Releases: ![GitHub all releases](https://img.shields.io/github/downloads/krishdevdb/reseter.css/total?style=flat-square)

And A 500 from other sources


