### PR TITLE
Add mobx-react-lite w/ npm auto-update

### DIFF
--- a/packages/m/mobx-react-lite.json
+++ b/packages/m/mobx-react-lite.json
@@ -22,7 +22,7 @@
   ],
   "autoupdate": {
     "source": "npm",
-    "target": "mobx-react",
+    "target": "mobx-react-lite",
     "fileMap": [
       {
         "basePath": "dist",

--- a/packages/m/mobx-react-lite.json
+++ b/packages/m/mobx-react-lite.json
@@ -1,0 +1,40 @@
+{
+  "name": "mobx-react-lite",
+  "filename": "mobxreactlite.umd.production.min.js",
+  "description": "Lightweight React bindings for MobX based on React 16.8+ and Hooks",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mobxjs/mobx.git"
+  },
+  "license": "MIT",
+  "homepage": "https://mobx.js.org/react-integration.html",
+  "keywords": [
+    "mobx",
+    "mobx-react-lite",
+    "hooks",
+    "fp",
+    "mobservable",
+    "react-component",
+    "react hooks",
+    "react",
+    "reactjs",
+    "reactive"
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "mobx-react",
+    "fileMap": [
+      {
+        "basePath": "dist",
+        "files": [
+          "mobxreact*.js"
+        ]
+      }
+    ]
+  },
+  "authors": [
+    {
+      "name": "Michel Weststrate"
+    }
+  ]
+}

--- a/packages/m/mobx-react-lite.json
+++ b/packages/m/mobx-react-lite.json
@@ -27,7 +27,7 @@
       {
         "basePath": "dist",
         "files": [
-          "mobxreact*.js"
+          "mobxreactlite*.js"
         ]
       }
     ]


### PR DESCRIPTION
Add mobx-react-lite cdnjs support, this is a new npm package, a lightweight React bindings for MobX based on React 16.8+ and Hooks.
/cc @mweststrate (mobx team leader) @MattIPv4 (cdnjs maintainer) please review, thanks!