### PR TITLE
Update element-plus w/ npm auto-update

### DIFF
--- a/packages/e/element-plus.json
+++ b/packages/e/element-plus.json
@@ -23,7 +23,7 @@
       {
         "basePath": "lib",
         "files": [
-          "umd/locale/*.js"
+          "umd/locale/*.js",
           "theme-chalk/*.css",
           "theme-chalk/fonts/*.@(ttf|woff)",
           "index.*.js"

--- a/packages/e/element-plus.json
+++ b/packages/e/element-plus.json
@@ -23,6 +23,7 @@
       {
         "basePath": "lib",
         "files": [
+          "umd/locale/*.js"
           "theme-chalk/*.css",
           "theme-chalk/fonts/*.@(ttf|woff)",
           "index.*.js"


### PR DESCRIPTION
Add missing `element-plus` international js file.
Same as `element-ui`:

<img src="https://user-images.githubusercontent.com/14012511/115690654-d68abf00-a38f-11eb-8713-fa97359f6c5b.png" width="600px">

/cc @MattIPv4  I am so sorry for this missing.