### PR TITLE
Add busuanzi w/ npm auto-update

### DIFF
--- a/packages/b/busuanzi.json
+++ b/packages/b/busuanzi.json
@@ -1,7 +1,7 @@
 {
   "name": "busuanzi",
   "filename": "bsz.pure.mini.min.js",
-  "description": "free cdn mirror support for busuanzi.ibruce.info js script",
+  "description": "cdn support for busuanzi.ibruce.info js script file",
   "repository": {
     "type": "git",
     "url": "https://github.com/SukkaW/busuanzi.git"

--- a/packages/b/busuanzi.json
+++ b/packages/b/busuanzi.json
@@ -22,7 +22,6 @@
       {
         "basePath": ".",
         "files": [
-          "bsz.pure.mini.min.js",
           "bsz.pure.mini.js"
         ]
       }

--- a/packages/b/busuanzi.json
+++ b/packages/b/busuanzi.json
@@ -1,0 +1,41 @@
+{
+  "name": "busuanzi",
+  "filename": "bsz.pure.mini.min.js",
+  "description": "free cdn mirror support for busuanzi.ibruce.info js script",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SukkaW/busuanzi.git"
+  },
+  "license": "MIT",
+  "homepage": "http://ibruce.info",
+  "keywords": [
+    "web analysis",
+    "page analysis",
+    "visit statistics",
+    "access logs",
+    "google analytics alternative"
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "busuanzi",
+    "fileMap": [
+      {
+        "basePath": ".",
+        "files": [
+          "bsz.pure.mini.min.js",
+          "bsz.pure.mini.js"
+        ]
+      }
+    ]
+  },
+  "authors": [
+    {
+      "name": "bruce sha",
+      "email": "bu.ru@qq.com"
+    },
+    {
+      "name": "sukkaw",
+      "email": "github@skk.moe"
+    }
+  ]
+}


### PR DESCRIPTION
Add busuanzi cdn support. busuanzi is a popular free webpage visit statistics in china mainland.

releative issue https://github.com/staticfile/static/issues/567
> staticfile.org is a mirror of cdnjs.org

/cc @SukkaW (npm mirror author) @MattIPv4 (cdnjs maintainer)