### PR TITLE
Add busuanzi w/ npm auto-update

### DIFF
--- a/packages/b/busuanzi.json
+++ b/packages/b/busuanzi.json
@@ -1,6 +1,6 @@
 {
   "name": "busuanzi",
-  "filename": "bsz.pure.mini.min.js",
+  "filename": "bsz.pure.mini.js",
   "description": "cdn support for busuanzi.ibruce.info js script file",
   "repository": {
     "type": "git",

--- a/packages/b/busuanzi.json
+++ b/packages/b/busuanzi.json
@@ -1,0 +1,40 @@
+{
+  "name": "busuanzi",
+  "filename": "bsz.pure.mini.min.js",
+  "description": "cdn support for busuanzi.ibruce.info js script file",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SukkaW/busuanzi.git"
+  },
+  "license": "MIT",
+  "homepage": "http://ibruce.info",
+  "keywords": [
+    "web analysis",
+    "page analysis",
+    "visit statistics",
+    "access logs",
+    "google analytics alternative"
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "busuanzi",
+    "fileMap": [
+      {
+        "basePath": ".",
+        "files": [
+          "bsz.pure.mini.js"
+        ]
+      }
+    ]
+  },
+  "authors": [
+    {
+      "name": "bruce sha",
+      "email": "bu.ru@qq.com"
+    },
+    {
+      "name": "sukkaw",
+      "email": "github@skk.moe"
+    }
+  ]
+}


### PR DESCRIPTION
Add busuanzi cdn support. busuanzi is a popular free webpage visit statistics in china mainland.

releative issue https://github.com/staticfile/static/issues/567
> staticfile.org is a mirror of cdnjs.org

/cc @SukkaW (npm mirror author) @MattIPv4 (cdnjs maintainer)