### PR TITLE
Update highlight.js w/ git auto-update

### DIFF
--- a/packages/h/highlight.js.json
+++ b/packages/h/highlight.js.json
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/isagalaev/highlight.js"
+    "url": "https://github.com/highlightjs/highlight.js"
   },
   "license": "BSD-3-Clause",
   "authors": [


### PR DESCRIPTION
Also, the CDN doesn't seem to be picking up our three latest versions/tags.

- 11.0.0
- 11.0.1
- 10.7.3

Could anyone help?  Our build process hasn't change or anything, we push releases to our CDN repo just like we always have...