### PR TITLE
Add datatables.net-bs5 et. al w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-bs5.json
+++ b/packages/d/datatables.net-bs5.json
@@ -1,0 +1,43 @@
+{
+  "name": "datatables.net-bs5",
+  "description": "DataTables for jQuery with styling for [Bootstrap 5](http://getbootstrap.com/)",
+  "keywords": [
+    "filter",
+    "sort",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap 5"
+  ],
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-Bootstrap5.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-bs5",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "dataTables.bootstrap5.min.js",
+  "authors": [
+    {
+      "name": "SpryMedia Ltd",
+      "url": "http://datatables.net"
+    }
+  ]
+}

--- a/packages/d/datatables.net-buttons-bs5.json
+++ b/packages/d/datatables.net-buttons-bs5.json
@@ -1,0 +1,47 @@
+{
+  "name": "datatables.net-buttons-bs5",
+  "description": "Buttons for DataTables with styling for [Bootstrap 5](http://getbootstrap.com/)",
+  "keywords": [
+    "buttons",
+    "excel",
+    "pdf",
+    "csv",
+    "column visibility",
+    "print",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap 5"
+  ],
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-Buttons-Bootstrap5.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-buttons-bs5",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "buttons.bootstrap5.min.js",
+  "authors": [
+    {
+      "name": "SpryMedia Ltd",
+      "url": "http://datatables.net"
+    }
+  ]
+}

--- a/packages/d/datatables.net-colreorder-bs5.json
+++ b/packages/d/datatables.net-colreorder-bs5.json
@@ -1,0 +1,42 @@
+{
+  "name": "datatables.net-colreorder-bs5",
+  "description": "ColReorder for DataTables with styling for [Bootstrap 5](http://getbootstrap.com/)",
+  "keywords": [
+    "reorder",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap 5"
+  ],
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-ColReorder-Bootstrap5.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-colreorder-bs5",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "colReorder.bootstrap5.min.js",
+  "authors": [
+    {
+      "name": "SpryMedia Ltd",
+      "url": "http://datatables.net"
+    }
+  ]
+}

--- a/packages/d/datatables.net-editor-bs5.json
+++ b/packages/d/datatables.net-editor-bs5.json
@@ -1,0 +1,40 @@
+{
+  "name": "datatables.net-editor-bs5",
+  "description": "DataTables Editor - Bootstrap 5 integration",
+  "keywords": [
+    "DataTables",
+    "Editor",
+    "Bootstrap"
+  ],
+  "license": "SEE LICENSE IN License.md",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-Editor-Bootstrap5.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-editor-bs5",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "editor.bootstrap5.min.js",
+  "authors": [
+    {
+      "name": "SpryMedia Ltd",
+      "url": "http://datatables.net"
+    }
+  ]
+}

--- a/packages/d/datatables.net-fixedcolumns-bs5.json
+++ b/packages/d/datatables.net-fixedcolumns-bs5.json
@@ -1,0 +1,42 @@
+{
+  "name": "datatables.net-fixedcolumns-bs5",
+  "description": "FixedColumns for DataTables with styling for [Bootstrap 5](http://getbootstrap.com/)",
+  "keywords": [
+    "fixed columns",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap 5"
+  ],
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-FixedColumns-Bootstrap5.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-fixedcolumns-bs5",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "fixedColumns.bootstrap5.min.js",
+  "authors": [
+    {
+      "name": "SpryMedia Ltd",
+      "url": "http://datatables.net"
+    }
+  ]
+}

--- a/packages/d/datatables.net-fixedheader-bs5.json
+++ b/packages/d/datatables.net-fixedheader-bs5.json
@@ -1,0 +1,43 @@
+{
+  "name": "datatables.net-fixedheader-bs5",
+  "description": "FixedHeader for DataTables with styling for [Bootstrap 5](http://getbootstrap.com/)",
+  "keywords": [
+    "fixed headers",
+    "sticky",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap 5"
+  ],
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-FixedHeader-Bootstrap5.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-fixedheader-bs5",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "fixedHeader.bootstrap5.min.js",
+  "authors": [
+    {
+      "name": "SpryMedia Ltd",
+      "url": "http://datatables.net"
+    }
+  ]
+}

--- a/packages/d/datatables.net-keytable-bs5.json
+++ b/packages/d/datatables.net-keytable-bs5.json
@@ -1,0 +1,44 @@
+{
+  "name": "datatables.net-keytable-bs5",
+  "description": "KeyTable for DataTables with styling for [Bootstrap 5](http://getbootstrap.com/)",
+  "keywords": [
+    "spreadsheet",
+    "excel",
+    "keyboard",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap 5"
+  ],
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-KeyTable-Bootstrap5.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-keytable-bs5",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "keyTable.bootstrap5.min.js",
+  "authors": [
+    {
+      "name": "SpryMedia Ltd",
+      "url": "http://datatables.net"
+    }
+  ]
+}

--- a/packages/d/datatables.net-responsive-bs5.json
+++ b/packages/d/datatables.net-responsive-bs5.json
@@ -1,0 +1,42 @@
+{
+  "name": "datatables.net-responsive-bs5",
+  "description": "Responsive for DataTables with styling for [Bootstrap 5](http://getbootstrap.com/)",
+  "keywords": [
+    "responsive",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap 5"
+  ],
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-Responsive-Bootstrap5.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-responsive-bs5",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "responsive.bootstrap5.min.js",
+  "authors": [
+    {
+      "name": "SpryMedia Ltd",
+      "url": "http://datatables.net"
+    }
+  ]
+}

--- a/packages/d/datatables.net-rowgroup-bs5.json
+++ b/packages/d/datatables.net-rowgroup-bs5.json
@@ -1,0 +1,42 @@
+{
+  "name": "datatables.net-rowgroup-bs5",
+  "description": "RowGroup for DataTables with styling for [Bootstrap 5](http://getbootstrap.com/)",
+  "keywords": [
+    "row grouping",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap 5"
+  ],
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-RowGroup-Bootstrap5.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-rowgroup-bs5",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "rowGroup.bootstrap5.min.js",
+  "authors": [
+    {
+      "name": "SpryMedia Ltd",
+      "url": "http://datatables.net"
+    }
+  ]
+}

--- a/packages/d/datatables.net-rowreorder-bs5.json
+++ b/packages/d/datatables.net-rowreorder-bs5.json
@@ -1,0 +1,42 @@
+{
+  "name": "datatables.net-rowreorder-bs5",
+  "description": "RowReorder for DataTables with styling for [Bootstrap 5](http://getbootstrap.com/)",
+  "keywords": [
+    "row reordering",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap 5"
+  ],
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-RowReorder-Bootstrap5.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-rowreorder-bs5",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "rowReorder.bootstrap5.min.js",
+  "authors": [
+    {
+      "name": "SpryMedia Ltd",
+      "url": "http://datatables.net"
+    }
+  ]
+}

--- a/packages/d/datatables.net-scroller-bs5.json
+++ b/packages/d/datatables.net-scroller-bs5.json
@@ -1,0 +1,42 @@
+{
+  "name": "datatables.net-scroller-bs5",
+  "description": "Scroller for DataTables with styling for [Bootstrap 5](http://getbootstrap.com/)",
+  "keywords": [
+    "virtual scrolling",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap 5"
+  ],
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-Scroller-Bootstrap5.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-scroller-bs5",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "scroller.bootstrap5.min.js",
+  "authors": [
+    {
+      "name": "SpryMedia Ltd",
+      "url": "http://datatables.net"
+    }
+  ]
+}

--- a/packages/d/datatables.net-searchpanes-bs5.json
+++ b/packages/d/datatables.net-searchpanes-bs5.json
@@ -1,0 +1,43 @@
+{
+  "name": "datatables.net-searchpanes-bs5",
+  "description": "SearchPanes for DataTables with styling for [Bootstrap](http://getbootstrap.com/)",
+  "keywords": [
+    "Search",
+    "Filter",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap"
+  ],
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-SearchPanes-Bootstrap5.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-searchpanes-bs5",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "searchPanes.bootstrap5.min.js",
+  "authors": [
+    {
+      "name": "SpryMedia Ltd",
+      "url": "http://datatables.net"
+    }
+  ]
+}

--- a/packages/d/datatables.net-select-bs5.json
+++ b/packages/d/datatables.net-select-bs5.json
@@ -1,0 +1,43 @@
+{
+  "name": "datatables.net-select-bs5",
+  "description": "Select for DataTables with styling for [Bootstrap 5](http://getbootstrap.com/)",
+  "keywords": [
+    "select",
+    "selection",
+    "DataTables",
+    "jQuery",
+    "table",
+    "Bootstrap 5"
+  ],
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-Select-Bootstrap5.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-select-bs5",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "select.bootstrap5.min.js",
+  "authors": [
+    {
+      "name": "SpryMedia Ltd",
+      "url": "http://datatables.net"
+    }
+  ]
+}


### PR DESCRIPTION
Add all datatables bs5 packages:
- datatables.net-bs5
- datatables.net-buttons-bs5
- datatables.net-colreorder-bs5
- datatables.net-editor-bs5
- datatables.net-fixedcolumns-bs5
- datatables.net-fixedheader-bs5
- datatables.net-keytable-bs5
- datatables.net-responsive-bs5
- datatables.net-rowgroup-bs5
- datatables.net-rowreorder-bs5
- datatables.net-scroller-bs5
- datatables.net-searchpanes-bs5
- datatables.net-select-bs5