### PR TITLE
Update mustache.js w/ npm auto-update

### DIFF
--- a/packages/m/mustache.js.json
+++ b/packages/m/mustache.js.json
@@ -10,14 +10,15 @@
     "ejs"
   ],
   "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/janl/mustache.js.git",
+    "source": "npm",
+    "target": "mustache",
     "fileMap": [
       {
         "basePath": "",
         "files": [
           "mustache.js",
-          "mustache.min.js"
+          "mustache.min.js",
+          "mustache.mjs"
         ]
       }
     ]


### PR DESCRIPTION
Previously the mustache git repository had its `mustache.js` source code written in UMD.

Recently a build step was introduced, where `mustache.js` in the git repository is now written in ESM syntax, but converted into UMD in the build process before being published to npm.

The ESM syntax alternative is still available as `mustache.mjs` in the npm package.

Refs https://github.com/janl/mustache.js/commit/cc979e0419e7a1aae6c14c1a59763324855a54f3#commitcomment-52315118

/cc @hammond13