### PR TITLE
Update noUiSlider w/ npm auto-update

### DIFF
--- a/packages/n/noUiSlider.json
+++ b/packages/n/noUiSlider.json
@@ -15,11 +15,11 @@
     "slide"
   ],
   "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/leongersen/noUiSlider.git",
+    "source": "npm",
+    "target": "nouislider",
     "fileMap": [
       {
-        "basePath": "distribute",
+        "basePath": "dist",
         "files": [
           "**/*"
         ]


### PR DESCRIPTION
See their [CHANGELOG.MD](https://github.com/leongersen/noUiSlider/blob/master/CHANGELOG.MD) for 15.0.0: 

> The distributed files have moved from distribute to dist in the NPM package, and are no longer in the repository; You may need to change the path to the noUiSlider CSS file if you are importing it using a package manager;

I'm not 100% sure if I got the syntax right.

And `"basePath": "dist"` isn't backwards compatible to versions 14.x and lower, but I guess that won't change the versions already in cdnjs.