### PR TITLE
Add prism-themes w/ git auto-update

### DIFF
--- a/packages/p/prism-themes.json
+++ b/packages/p/prism-themes.json
@@ -1,0 +1,28 @@
+{
+  "name": "prism-themes",
+  "description": "Additional themes for the Prism syntax highlighting library.",
+  "keywords": [],
+  "license": "MIT",
+  "homepage": "https://github.com/prismjs/prism-themes#readme",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/PrismJS/prism-themes.git"
+  },
+  "authors": [
+    {
+      "name": "Lea Verou"
+    }
+  ],
+  "autoupdate": {
+    "source": "git",
+    "target": "git://github.com/PrismJS/prism-themes.git",
+    "fileMap": [
+      {
+        "basePath": "themes",
+        "files": [
+          "*.css"
+        ]
+      }
+    ]
+  }
+}

--- a/packages/p/prism-themes.json
+++ b/packages/p/prism-themes.json
@@ -1,7 +1,10 @@
 {
   "name": "prism-themes",
   "description": "Additional themes for the Prism syntax highlighting library.",
-  "keywords": [],
+  "keywords": [
+    "prism",
+    "prismjs"
+  ],
   "license": "MIT",
   "homepage": "https://github.com/prismjs/prism-themes#readme",
   "repository": {


### PR DESCRIPTION
Adding prism-themes using git auto-update from git://github.com/PrismJS/prism-themes.git.

Resolves #855.