### PR TITLE
Update jasmine w/ git auto-update

### DIFF
--- a/packages/j/jasmine.json
+++ b/packages/j/jasmine.json
@@ -23,9 +23,6 @@
           "jasmine.css"
         ]
       }
-    ],
-    "ignoreVersions": [
-      "list"
     ]
   },
   "repository": {


### PR DESCRIPTION
This adds `jasmine_favicion.png`, `boot0.js`, and `boot1.js` to fix jasmine/jasmine#1935. The latter two files were [added in 3.9.0](https://github.com/jasmine/jasmine/commit/286524959be077cd6c8cfd8236848ea731d8b5c4). They'll eventually replace `boot.js`, but Jasmine will ship all three for the remainder of 3.x. 