### PR TITLE
Update vue-tour w/ npm auto-update

### DIFF
--- a/packages/v/vue-tour.json
+++ b/packages/v/vue-tour.json
@@ -21,7 +21,8 @@
       {
         "basePath": "dist",
         "files": [
-          "*.js"
+          "*.js",
+          "*.css",
         ]
       }
     ]

--- a/packages/v/vue-tour.json
+++ b/packages/v/vue-tour.json
@@ -22,7 +22,7 @@
         "basePath": "dist",
         "files": [
           "*.js",
-          "*.css",
+          "*.css"
         ]
       }
     ]

--- a/packages/v/vue-tour.json
+++ b/packages/v/vue-tour.json
@@ -1,7 +1,7 @@
 {
   "name": "vue-tour",
   "filename": "vue-tour.umd.min.js",
-  "description": "state management for Vue.js",
+  "description": "Vue Tour is a lightweight, simple and customizable tour plugin for use with Vue.js. It provides a quick and easy way to guide your users through your application.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/pulsardev/vue-tour.git"


### PR DESCRIPTION
- Updated the package description from the official site.
- Added css files in CDN

### Issue:
- Your site still shows the old github url (Gihub link on https://cdnjs.com/libraries/vue-tour) instead of the official one you see above.