### PR TITLE
Add mapbox-gl-legend w/ npm auto-update

### DIFF
--- a/packages/m/mapbox-gl-legend.json
+++ b/packages/m/mapbox-gl-legend.json
@@ -7,8 +7,11 @@
     "legend"
   ],
   "license": "MIT",
-  "homepage": "",
-  "repository": {},
+  "homepage": "https://github.com/watergis/mapbox-gl-legend#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/watergis/mapbox-gl-legend.git"
+  },
   "authors": [
     {
       "name": "Jin IGARASHI"

--- a/packages/m/mapbox-gl-legend.json
+++ b/packages/m/mapbox-gl-legend.json
@@ -1,0 +1,36 @@
+{
+  "name": "mapbox-gl-legend",
+  "description": "This module adds legend control which is able to create legend panel from mapbox style to mapbox-gl",
+  "keywords": [
+    "mapbox",
+    "mapbox-gl-js",
+    "legend"
+  ],
+  "license": "MIT",
+  "homepage": "",
+  "repository": {},
+  "authors": [
+    {
+      "name": "Jin IGARASHI"
+    }
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "@watergis/mapbox-gl-legend",
+    "fileMap": [
+      {
+        "basePath": "dist/cdn",
+        "files": [
+          "*.@(js|css)"
+        ]
+      },
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      }
+    ]
+  },
+  "filename": "mapbox-gl-legend.js"
+}


### PR DESCRIPTION
Adding mapbox-gl-legend using npm auto-update from @watergis/mapbox-gl-legend.

Resolves #907.