### PR TITLE
Add argon2-browser w/ npm auto-update

### DIFF
--- a/packages/a/argon2-browser.json
+++ b/packages/a/argon2-browser.json
@@ -1,0 +1,29 @@
+{
+  "name": "argon2-browser",
+  "description": "Argon2 library compiled for browser runtime",
+  "keywords": [],
+  "license": "MIT",
+  "homepage": "https://github.com/antelle/argon2-browser#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/antelle/argon2-browser.git"
+  },
+  "authors": [
+    {
+      "name": "Antelle"
+    }
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "argon2-browser",
+    "fileMap": [
+      {
+        "basePath": "dist",
+        "files": [
+          "*.@(js|wasm)"
+        ]
+      }
+    ]
+  },
+  "filename": "argon2-bundled.min.js"
+}

--- a/packages/a/argon2-browser.json
+++ b/packages/a/argon2-browser.json
@@ -1,7 +1,15 @@
 {
   "name": "argon2-browser",
   "description": "Argon2 library compiled for browser runtime",
-  "keywords": [],
+  "keywords": [
+    "argon2",
+    "keeweb",
+    "webassembly",
+    "wasm",
+    "hash",
+    "keepass",
+    "kdf"
+  ],
   "license": "MIT",
   "homepage": "https://github.com/antelle/argon2-browser#readme",
   "repository": {


### PR DESCRIPTION
Adding argon2-browser using npm auto-update from argon2-browser.

Resolves #936.