### PR TITLE
Add chiron-sans-hk w/ git auto-update

### DIFF
--- a/packages/c/chiron-sans-hk.json
+++ b/packages/c/chiron-sans-hk.json
@@ -1,0 +1,35 @@
+{
+  "name": "chiron-sans-hk",
+  "description": "昭源黑體：現代筆形風格，平衡標準字形和印刷體慣用筆形的免費開源黑體字型",
+  "keywords": [
+    "font",
+    "typeface",
+    "hongkong",
+    "opentype",
+    "otf"
+  ],
+  "license": "OFL-1.1",
+  "homepage": "https://chiron-fonts.github.io/sans/",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/chiron-fonts/chiron-sans-hk.git"
+  },
+  "authors": [
+    {
+      "name": "chiron-fonts"
+    }
+  ],
+  "autoupdate": {
+    "source": "git",
+    "target": "git://github.com/chiron-fonts/chiron-sans-hk.git",
+    "fileMap": [
+      {
+        "basePath": "build",
+        "files": [
+          "**/*.@(otf|ttf|woff2|css)"
+        ]
+      }
+    ]
+  },
+  "filename": "webfont/css/vf.css"
+}


### PR DESCRIPTION
Adding chiron-sans-hk using git auto-update from git://github.com/chiron-fonts/chiron-sans-hk.git.

Resolves #937.