### PR TITLE
Add chiron-sans-hk-pro w/ git auto-update

### DIFF
--- a/packages/c/chiron-sans-hk-pro.json
+++ b/packages/c/chiron-sans-hk-pro.json
@@ -1,0 +1,29 @@
+{
+  "name": "chiron-sans-hk-pro",
+  "description": "Chiron Sans HK + Source Sans 3 = Chiron Sans HK Pro",
+  "keywords": [],
+  "license": "OFL-1.1",
+  "homepage": "https://chiron-fonts.github.io/sans/",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/chiron-fonts/chiron-sans-hk-pro.git"
+  },
+  "authors": [
+    {
+      "name": "chiron-fonts"
+    }
+  ],
+  "autoupdate": {
+    "source": "git",
+    "target": "git://github.com/chiron-fonts/chiron-sans-hk-pro.git",
+    "fileMap": [
+      {
+        "basePath": "build",
+        "files": [
+          "**/*.@(otf|ttf|woff2|css)"
+        ]
+      }
+    ]
+  },
+  "filename": "webfont/css/vf.css"
+}

--- a/packages/c/chiron-sans-hk-pro.json
+++ b/packages/c/chiron-sans-hk-pro.json
@@ -1,7 +1,11 @@
 {
   "name": "chiron-sans-hk-pro",
   "description": "Chiron Sans HK + Source Sans 3 = Chiron Sans HK Pro",
-  "keywords": [],
+  "keywords": [
+    "font",
+    "chiron",
+    "hk"
+  ],
   "license": "OFL-1.1",
   "homepage": "https://chiron-fonts.github.io/sans/",
   "repository": {


### PR DESCRIPTION
Adding chiron-sans-hk-pro using git auto-update from git://github.com/chiron-fonts/chiron-sans-hk-pro.git.

Resolves #937.