### PR TITLE
Add sentry-browser w/ npm auto-update

### DIFF
--- a/packages/s/sentry-browser.json
+++ b/packages/s/sentry-browser.json
@@ -1,7 +1,13 @@
 {
   "name": "sentry-browser",
   "description": "Official Sentry SDK for browsers",
-  "keywords": [],
+  "keywords": [
+    "crash-reporting",
+    "error-monitoring",
+    "sentry",
+    "raven",
+    "sentry-client"
+  ],
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/browser",
   "repository": {

--- a/packages/s/sentry-browser.json
+++ b/packages/s/sentry-browser.json
@@ -1,0 +1,29 @@
+{
+  "name": "sentry-browser",
+  "description": "Official Sentry SDK for browsers",
+  "keywords": [],
+  "license": "BSD-3-Clause",
+  "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/browser",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/getsentry/sentry-javascript.git"
+  },
+  "authors": [
+    {
+      "name": "Sentry"
+    }
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "@sentry/browser",
+    "fileMap": [
+      {
+        "basePath": "build",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "bundle.min.js"
+}


### PR DESCRIPTION
Adding sentry-browser using npm auto-update from @sentry/browser.

Resolves #1030.