### PR TITLE
Add sentry-tracing w/ npm auto-update

### DIFF
--- a/packages/s/sentry-tracing.json
+++ b/packages/s/sentry-tracing.json
@@ -1,0 +1,29 @@
+{
+  "name": "sentry-tracing",
+  "description": "Extensions for Sentry AM",
+  "keywords": [],
+  "license": "MIT",
+  "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/tracing",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/getsentry/sentry-javascript.git"
+  },
+  "authors": [
+    {
+      "name": "Sentry"
+    }
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "@sentry/tracing",
+    "fileMap": [
+      {
+        "basePath": "build",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "bundle.tracing.min.js"
+}

--- a/packages/s/sentry-tracing.json
+++ b/packages/s/sentry-tracing.json
@@ -1,7 +1,13 @@
 {
   "name": "sentry-tracing",
   "description": "Extensions for Sentry AM",
-  "keywords": [],
+  "keywords": [
+    "crash-reporting",
+    "error-monitoring",
+    "sentry",
+    "raven",
+    "sentry-client"
+  ],
   "license": "MIT",
   "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/tracing",
   "repository": {


### PR DESCRIPTION
Adding sentry-tracing using npm auto-update from @sentry/tracing.

Resolves #1031.