### PR TITLE
Include textarea for files in library request

### DIFF
--- a/.github/ISSUE_TEMPLATE/library-request.yml
+++ b/.github/ISSUE_TEMPLATE/library-request.yml
@@ -43,3 +43,14 @@ body:
     placeholder: "https://www.npmjs.com/package/bootstrap"
   validations:
     required: true
+
+- type: textarea
+  id: files
+  attributes:
+    label: Files to include
+    description: "Please provide a list of all the files that we should include from the source for the library on cdnjs"
+    placeholder: |
+      - bootstrap.min.css
+      - bootstrap.min.js
+  validations:
+    required: true


### PR DESCRIPTION
As is already present in the update request template, include a textarea in the library request template for users to list out what files should be included when a library is requested to be added to cdnjs.