### PR TITLE
Update jquery_lazyload w/ npm auto-update

### DIFF
--- a/packages/j/jquery_lazyload.json
+++ b/packages/j/jquery_lazyload.json
@@ -1,22 +1,21 @@
 {
   "name": "jquery_lazyload",
-  "filename": "jquery.lazyload.min.js",
+  "filename": "lazyload.min.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/tuupola/jquery_lazyload.git"
+    "url": "https://github.com/tuupola/lazyload.git"
   },
   "keywords": [
     "jquery-plugin",
     "ecosystem:jquery"
   ],
   "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/tuupola/jquery_lazyload.git",
+    "source": "npm",
+    "target": "lazyload",
     "fileMap": [
       {
-        "basePath": "",
         "files": [
-          "jquery.lazyload.*"
+          "lazyload.*"
         ]
       }
     ]

--- a/packages/j/jquery_lazyload.json
+++ b/packages/j/jquery_lazyload.json
@@ -14,6 +14,7 @@
     "target": "lazyload",
     "fileMap": [
       {
+        "basePath": "",
         "files": [
           "lazyload.*"
         ]


### PR DESCRIPTION
The project was renamed, and the old url https://github.com/tuupola/jquery_lazyload now redirects to the new one. New versions seem to be released via npm.

I would like to use the latest version `2.0.0-rc.2`