### PR TITLE
Add react-minimal-datetime-range w/ npm auto-update

### DIFF
--- a/packages/r/react-minimal-datetime-range.json
+++ b/packages/r/react-minimal-datetime-range.json
@@ -1,0 +1,44 @@
+{
+  "name": "react-minimal-datetime-range",
+  "description": "A react component for date time range picker.",
+  "keywords": [
+    "react",
+    "minimal",
+    "range",
+    "picky",
+    "date",
+    "time",
+    "picker",
+    "datepicker",
+    "date-picker",
+    "timepicker",
+    "time-picker",
+    "calendar",
+    "react-minimal-datetime-range"
+  ],
+  "license": "MIT",
+  "homepage": "https://edwardfxiao.github.io/react-minimal-datetime-range",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/edwardfxiao/react-minimal-datetime-range.git"
+  },
+  "authors": [
+    {
+      "name": "Edward Xiao"
+    }
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "react-minimal-datetime-range",
+    "fileMap": [
+      {
+        "basePath": "lib",
+        "files": [
+          "{,components/}*.@(css|js)?(.map)",
+          "{,components/}*.d.ts"
+        ]
+      }
+    ]
+  },
+  "filename": "react-minimal-datetime-range.min.js"
+}


### PR DESCRIPTION
Adding react-minimal-datetime-range using npm auto-update from react-minimal-datetime-range.

Resolves #1118.