### PR TITLE
Update europa w/ npm auto-update

### DIFF
--- a/packages/e/europa.json
+++ b/packages/e/europa.json
@@ -10,15 +10,16 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/NotNinja/europa.git"
+    "url": "https://github.com/neocotic/europa.git",
+    "directory":  "packages/europa"
   },
-  "filename": "europa.min.js",
+  "filename": "europa.js",
   "autoupdate": {
     "source": "npm",
     "target": "europa",
     "fileMap": [
       {
-        "basePath": "dist",
+        "basePath": "lib/umd",
         "files": [
           "**/*"
         ]
@@ -30,9 +31,8 @@
   },
   "authors": [
     {
-      "name": "Alasdair Mercer",
-      "email": "mercer.alasdair@gmail.com",
-      "url": "https://not.ninja"
+      "name": "neocotic",
+      "url": "https://github.com/neocotic"
     }
   ]
 }

--- a/packages/e/europa.json
+++ b/packages/e/europa.json
@@ -10,8 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/neocotic/europa.git",
-    "directory":  "packages/europa"
+    "url": "https://github.com/neocotic/europa.git"
   },
   "filename": "europa.js",
   "autoupdate": {
@@ -21,12 +20,9 @@
       {
         "basePath": "lib/umd",
         "files": [
-          "**/*"
+          "*.js?(.map)"
         ]
       }
-    ],
-    "ignoreVersions": [
-      "4.0.0-alpha*"
     ]
   },
   "authors": [


### PR DESCRIPTION
Europa's configuration has changed post-v5 due to a move in repositories as well as a change in the structure of its distribution files.