### PR TITLE
Add jslint w/ git auto-update

### DIFF
--- a/packages/j/jslint.json
+++ b/packages/j/jslint.json
@@ -1,0 +1,35 @@
+{
+  "name": "jslint",
+  "description": "JSLint, The JavaScript Code Quality and Coverage Tool",
+  "keywords": [
+    "coverage-report",
+    "javascript",
+    "jslint",
+    "zero-config",
+    "zero-dependency"
+  ],
+  "license": "UNLICENSE",
+  "homepage": "https://www.jslint.com",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/jslint-org/jslint.git"
+  },
+  "authors": [
+    {
+      "name": "jslint-org"
+    }
+  ],
+  "autoupdate": {
+    "source": "git",
+    "target": "git://github.com/jslint-org/jslint.git",
+    "fileMap": [
+      {
+        "basePath": "",
+        "files": [
+          "jslint.mjs"
+        ]
+      }
+    ]
+  },
+  "filename": "jslint.mjs"
+}


### PR DESCRIPTION
Adding jslint using git auto-update from git://github.com/jslint-org/jslint.git.

Resolves #1134.