### PR TITLE
Add datatables.net-searchpanes-bs w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-searchpanes-bs.json
+++ b/packages/d/datatables.net-searchpanes-bs.json
@@ -1,0 +1,46 @@
+{
+  "name": "datatables.net-searchpanes-bs",
+  "description": "SearchPanes for DataTables with styling for [Bootstrap](https://getbootstrap.com/docs/3.3/)",
+  "keywords": [
+    "SearchPanes",
+    "search",
+    "filtering",
+    "Bootstrap",
+    "Datatables",
+    "jQuery",
+    "table",
+    "filter",
+    "sort"
+  ],
+  "license": "MIT",
+  "homepage": "https://datatables.net",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-SearchPanes-Bootstrap.git"
+  },
+  "authors": [
+    {
+      "name": "SpryMedia Ltd",
+      "url": "http://datatables.net"
+    }
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-searchpanes-bs",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "searchPanes.bootstrap.js"
+}


### PR DESCRIPTION
Adding datatables.net-searchpanes-bs using npm auto-update from datatables.net-searchpanes-bs.

Resolves #1151.