### PR TITLE
Update jodit w/ npm auto-update

### DIFF
--- a/packages/j/jodit.json
+++ b/packages/j/jodit.json
@@ -21,7 +21,8 @@
       {
         "basePath": "build",
         "files": [
-          "jodit*.+(css|js)"
+          "jodit*.+(css|js)",
+          "**/*"
         ]
       }
     ]

--- a/packages/j/jodit.json
+++ b/packages/j/jodit.json
@@ -22,7 +22,7 @@
         "basePath": "build",
         "files": [
           "jodit*.+(css|js)",
-          "plugins/**/*.(css|js)"
+          "plugins/**/*.@(css|js)"
         ]
       }
     ]

--- a/packages/j/jodit.json
+++ b/packages/j/jodit.json
@@ -22,7 +22,7 @@
         "basePath": "build",
         "files": [
           "jodit*.+(css|js)",
-          "**/*"
+          "plugins/**/*.(css|js)"
         ]
       }
     ]


### PR DESCRIPTION
I want to separate some of the plugins from the general build so as not to bloat the main file
Therefore, it is necessary that internal folders in build be laid out in cdn

https://github.com/xdan/jodit/tree/master/build plugins folder