### PR TITLE
Add hexoplusplus w/ npm auto-update

### DIFF
--- a/packages/h/hexoplusplus.json
+++ b/packages/h/hexoplusplus.json
@@ -8,7 +8,7 @@
             {
                 "basePath": "dist",
                 "files": [
-                    "*.@(js|css)"
+                    "**/*.@(js|css)"
                 ]
             }
         ]

--- a/packages/h/hexoplusplus.json
+++ b/packages/h/hexoplusplus.json
@@ -8,8 +8,7 @@
             {
                 "basePath": "dist",
                 "files": [
-                    "./*.js",
-                    "./*.css"
+                    "*.@(js|css)"
                 ]
             }
         ]

--- a/packages/h/hexoplusplus.json
+++ b/packages/h/hexoplusplus.json
@@ -8,8 +8,8 @@
             {
                 "basePath": "dist",
                 "files": [
-                    "/*.js",
-                    "/*.css"
+                    "./*.js",
+                    "./*.css"
                 ]
             }
         ]

--- a/packages/h/hexoplusplus.json
+++ b/packages/h/hexoplusplus.json
@@ -1,8 +1,6 @@
 {
     "name": "hexoplusplus",
-    "version": "0.1.0",
     "description": "A Serverless Hexo Back DashBoard",
-    "main": "index.js",
     "autoupdate": {
         "source": "npm",
         "target": "hexoplusplus",
@@ -16,7 +14,7 @@
             }
         ]
     },
-    "author": [
+    "authors": [
         {
             "name": "ChenYFan",
             "email": "chen2778754364@foxmail.com"
@@ -31,8 +29,5 @@
         "Hexo",
         "BackDashboard"
     ],
-    "bugs": {
-        "url": "https://github.com/HexoPlusPlus/HexoPlusPlus/issues"
-    },
     "homepage": "https://github.com/HexoPlusPlus/HexoPlusPlus#readme"
 }

--- a/packages/h/hexoplusplus.json
+++ b/packages/h/hexoplusplus.json
@@ -1,0 +1,38 @@
+{
+    "name": "hexoplusplus",
+    "version": "0.1.0",
+    "description": "A Serverless Hexo Back DashBoard",
+    "main": "index.js",
+    "autoupdate": {
+        "source": "npm",
+        "target": "hexoplusplus",
+        "fileMap": [
+            {
+                "basePath": "dist",
+                "files": [
+                    "/*.js",
+                    "/*.css"
+                ]
+            }
+        ]
+    },
+    "author": [
+        {
+            "name": "ChenYFan",
+            "email": "chen2778754364@foxmail.com"
+        }
+    ],
+    "license": "GPL-3.0",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/HexoPlusPlus/HexoPlusPlus.git"
+    },
+    "keywords": [
+        "Hexo",
+        "BackDashboard"
+    ],
+    "bugs": {
+        "url": "https://github.com/HexoPlusPlus/HexoPlusPlus/issues"
+    },
+    "homepage": "https://github.com/HexoPlusPlus/HexoPlusPlus#readme"
+}


### PR DESCRIPTION
**Library name:** hexoplusplus
**Git repository url:** [HexoPlusPlus/HexoPlusPlus](https://github.com/HexoPlusPlus/HexoPlusPlus)
**npm package name or url** (if there is one): [npmjs.com/hexoplusplus]
**License (List them all if it's multiple):** [GPL-3.0]
**Official homepage:** [https://hexoplusplus.js.org/]
**Wanna say something? Leave message here:** N/A


[license]:https://github.com/HexoPlusPlus/HexoPlusPlus/blob/main/LICENSE
[git-repository-url]: https://github.com/HexoPlusPlus/HexoPlusPlus.git
[homepage]:http://hexoplusplus.js.org
[npm]:https://www.npmjs.com/package/hexoplusplus



# Necessary check items
  * [x] I am the author of this library
    * [x] I would like to add a link to cdnjs on my website or repository
  * [x] This lib does not appear in cdnjs
  * [x] No duplicate issues/merge requests
  * [x] This lib has notable popularity
    * [x] > 200 [stars/followers/spawns] on [GitHub/Bitbucket]
    * [x] > 800 downloads per month on npm
  * [x] The project has been published on a well-known platform (or on npm)