### PR TITLE
Add leaflet-extra-markers w/ npm auto-update

### DIFF
--- a/packages/l/leaflet-extra-markers.json
+++ b/packages/l/leaflet-extra-markers.json
@@ -1,0 +1,32 @@
+{
+  "name": "leaflet-extra-markers",
+  "description": "Custom Markers for Leaflet JS based on Awesome Markers",
+  "keywords": [],
+  "license": "",
+  "homepage": "https://github.com/coryasilva/Leaflet.ExtraMarkers#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/coryasilva/Leaflet.ExtraMarkers.git"
+  },
+  "authors": [
+    {
+      "name": "coryasilva",
+      "email": "https://github.com/coryasilva"
+    }
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "leaflet-extra-markers",
+    "fileMap": [
+      {
+        "basePath": "dist",
+        "files": [
+          "css/*.css",
+          "img/*.png",
+          "js/*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "css/leaflet.extra-markers.min.css"
+}

--- a/packages/l/leaflet-extra-markers.json
+++ b/packages/l/leaflet-extra-markers.json
@@ -1,8 +1,11 @@
 {
   "name": "leaflet-extra-markers",
   "description": "Custom Markers for Leaflet JS based on Awesome Markers",
-  "keywords": [],
-  "license": "",
+  "keywords": [
+    "leaflet-js",
+    "marker"
+  ],
+  "license": "MIT",
   "homepage": "https://github.com/coryasilva/Leaflet.ExtraMarkers#readme",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adding leaflet-extra-markers using npm auto-update from leaflet-extra-markers.

Resolves #1203.