### PR TITLE
Add element-plus-icons-vue w/ npm auto-update

### DIFF
--- a/packages/e/element-plus-icons-vue.json
+++ b/packages/e/element-plus-icons-vue.json
@@ -11,10 +11,14 @@
   "homepage": "https://element-plus.org/",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/element-plus/element-plus-icons.git",
-    "directory": "packages/vue"
+    "url": "git+https://github.com/element-plus/element-plus-icons.git"
   },
-  "authors": [],
+  "authors": [
+    {
+      "name": "element-plus-icons contributors",
+      "url": "https://github.com/element-plus/element-plus-icons/graphs/contributors"
+    }
+  ],
   "autoupdate": {
     "source": "npm",
     "target": "@element-plus/icons-vue",

--- a/packages/e/element-plus-icons-vue.json
+++ b/packages/e/element-plus-icons-vue.json
@@ -1,0 +1,31 @@
+{
+  "name": "element-plus-icons-vue",
+  "description": "Vue components of Element Plus Icons collection.",
+  "keywords": [
+    "icon",
+    "svg",
+    "vue",
+    "element-plus"
+  ],
+  "license": "MIT",
+  "homepage": "https://element-plus.org/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/element-plus/element-plus-icons.git",
+    "directory": "packages/vue"
+  },
+  "authors": [],
+  "autoupdate": {
+    "source": "npm",
+    "target": "@element-plus/icons-vue",
+    "fileMap": [
+      {
+        "basePath": "dist",
+        "files": [
+          "*.@(js|cjs)?(.map)"
+        ]
+      }
+    ]
+  },
+  "filename": "index.min.js"
+}


### PR DESCRIPTION
Adding element-plus-icons-vue using npm auto-update from @element-plus/icons-vue.

Resolves #1318.