### PR TITLE
Update merger w/ git auto-update

### DIFF
--- a/packages/m/merger.json
+++ b/packages/m/merger.json
@@ -27,7 +27,9 @@
         "basePath": "assets",
         "files": [
           "js/*.js",
-          "styles/*.css"
+          "styles/*.css",
+          "bundles/*.js",
+          "bundles/*.css"
         ]
       }
     ]

--- a/packages/m/merger.json
+++ b/packages/m/merger.json
@@ -34,5 +34,5 @@
       }
     ]
   },
-  "filename": "js/function.min.js"
+  "filename": "bundles/function.main.js"
 }


### PR DESCRIPTION
Starting with https://github.com/qr-merger/merger/pull/35 `0.28.0-rc`, it will bundle all minified css/js and export them to the `/assets/bundle/ folder`. This pull request is adding the path to the configuration file.

Additionally, I am not sure if cdnjs.com would host a small amount of images for my project. There is a placeholder image https://github.com/qr-merger/merger/blob/master/assets/images/placeholder.png that could be benefited if cdnjs can host it, but it's fine as well otherwise.

```
  "autoupdate": {
    "source": "git",
    "target": "git://github.com/qr-merger/merger.git",
    "fileMap": [
      {
        "basePath": "assets",
        "files": [
          "js/*.js",
          "styles/*.css",
          "bundles/*.js",
          "bundles/*.css",
          "images/*.png"
        ]
      }
    ]
  },
```