### PR TITLE
Update otpauth w/ git auto-update

### DIFF
--- a/packages/o/otpauth.json
+++ b/packages/o/otpauth.json
@@ -31,7 +31,7 @@
     "type": "git",
     "url": "https://github.com/hectorm/otpauth.git"
   },
-  "filename": "otpauth.cjs.min.js",
+  "filename": "otpauth.esm.min.js",
   "autoupdate": {
     "source": "git",
     "target": "git://github.com/hectorm/otpauth.git",
@@ -39,12 +39,7 @@
       {
         "basePath": "dist",
         "files": [
-          "*.js?(.map)"
-        ]
-      },
-      {
-        "basePath": "types",
-        "files": [
+          "*.{js,mjs,cjs}?(.map)",
           "*.d.ts"
         ]
       }


### PR DESCRIPTION
The new `9.0.0` version has changed the name of the generated files.