### PR TITLE
Add canvaskit-wasm w/ npm auto-update

### DIFF
--- a/packages/c/canvaskit-wasm.json
+++ b/packages/c/canvaskit-wasm.json
@@ -1,11 +1,24 @@
 {
   "name": "canvaskit-wasm",
   "description": "A WASM version of Skia's Canvas API",
-  "keywords": [],
+  "keywords": [
+    "drawing",
+    "canvas",
+    "graphics",
+    "wasm"
+  ],
   "license": "BSD-3-Clause",
   "homepage": "https://github.com/google/skia/tree/main/modules/canvaskit",
-  "repository": {},
-  "authors": [],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/google/skia.git"
+  },
+  "authors": [
+    {
+      "name": "skia contribtors",
+      "url": "https://github.com/google/skia/graphs/contributors"
+    }
+  ],
   "autoupdate": {
     "source": "npm",
     "target": "canvaskit-wasm",

--- a/packages/c/canvaskit-wasm.json
+++ b/packages/c/canvaskit-wasm.json
@@ -1,0 +1,22 @@
+{
+  "name": "canvaskit-wasm",
+  "description": "A WASM version of Skia's Canvas API",
+  "keywords": [],
+  "license": "BSD-3-Clause",
+  "homepage": "https://github.com/google/skia/tree/main/modules/canvaskit",
+  "repository": {},
+  "authors": [],
+  "autoupdate": {
+    "source": "npm",
+    "target": "canvaskit-wasm",
+    "fileMap": [
+      {
+        "basePath": "bin",
+        "files": [
+          "canvaskit.@(js|wasm)"
+        ]
+      }
+    ]
+  },
+  "filename": "canvaskit.js"
+}


### PR DESCRIPTION
Adding canvaskit-wasm using npm auto-update from canvaskit-wasm.

Resolves #1381.