### PR TITLE
Update oauth4webapi w/ npm auto-update

### DIFF
--- a/packages/o/oauth4webapi.json
+++ b/packages/o/oauth4webapi.json
@@ -8,13 +8,17 @@
     "authorization",
     "basic",
     "browser",
+    "bun",
     "certified",
     "client",
-    "cloudflare-workers",
+    "cloudflare",
     "deno",
+    "edge",
     "electron",
     "fapi",
     "javascript",
+    "netlify",
+    "next",
     "nextjs",
     "node",
     "nodejs",
@@ -23,7 +27,8 @@
     "oidc",
     "openid-connect",
     "openid",
-    "vercel-edge"
+    "vercel",
+    "workers"
   ],
   "homepage": "https://github.com/panva/oauth4webapi",
   "repository": {
@@ -38,7 +43,7 @@
   ],
   "autoupdate": {
     "source": "npm",
-    "target": "@panva/oauth4webapi",
+    "target": "oauth4webapi",
     "fileMap": [
       {
         "basePath": "build",


### PR DESCRIPTION
The package has moved from [@panva/oauth4webapi](https://www.npmjs.com/package/@panva/oauth4webapi) to [oauth4webapi](https://www.npmjs.com/package/oauth4webapi)