### PR TITLE
Add google-closure-library w/ npm auto-update

### DIFF
--- a/packages/g/google-closure-library.json
+++ b/packages/g/google-closure-library.json
@@ -1,0 +1,34 @@
+{
+  "name": "google-closure-library",
+  "description": "Google's common JavaScript library",
+  "keywords": [
+    "javascript",
+    "library",
+    "goog",
+    "closure"
+  ],
+  "license": "Apache-2.0",
+  "homepage": "https://developers.google.com/closure/library/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/google/closure-library.git"
+  },
+  "authors": [
+    {
+      "name": "The Closure Library Authors"
+    }
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "google-closure-library",
+    "fileMap": [
+      {
+        "basePath": "closure/goog",
+        "files": [
+          "base.js"
+        ]
+      }
+    ]
+  },
+  "filename": "base.js"
+}


### PR DESCRIPTION
Adding google-closure-library using npm auto-update from google-closure-library.

Resolves #1447.