### PR TITLE
Update xregexp.json w/ npm auto-update

### DIFF
--- a/packages/x/xregexp.json
+++ b/packages/x/xregexp.json
@@ -5,7 +5,9 @@
   "homepage": "http://xregexp.com/",
   "keywords": [
     "regex",
-    "regexp"
+    "regexp",
+    "regular expression",
+    "unicode"
   ],
   "repository": {
     "type": "git",
@@ -13,8 +15,8 @@
   },
   "license": "MIT",
   "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/slevithan/XRegExp.git",
+    "source": "npm",
+    "target": "xregexp",
     "fileMap": [
       {
         "basePath": "",


### PR DESCRIPTION
xregexp-all.js is not included in the github repository, switching the autoupdate to npm.