### PR TITLE
Add mapcreator-api w/ npm auto-update

### DIFF
--- a/packages/m/mapcreator-api.json
+++ b/packages/m/mapcreator-api.json
@@ -1,7 +1,10 @@
 {
   "name": "mapcreator-api",
   "description": "Mapcreator JavaScript API",
-  "keywords": [],
+  "keywords": [
+    "mapping",
+    "api"
+  ],
   "license": "BSD-3-Clause",
   "homepage": "https://gitlab.com/mapcreator/api-wrapper#readme",
   "repository": {

--- a/packages/m/mapcreator-api.json
+++ b/packages/m/mapcreator-api.json
@@ -1,0 +1,30 @@
+{
+  "name": "mapcreator-api",
+  "description": "Mapcreator JavaScript API",
+  "keywords": [],
+  "license": "BSD-3-Clause",
+  "homepage": "https://gitlab.com/mapcreator/api-wrapper#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://gitlab.com/mapcreator/api-wrapper.git"
+  },
+  "authors": [
+    {
+      "name": "Bas Bieling",
+      "email": "b.bieling@mapcreator.eu"
+    }
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "@mapcreator/api",
+    "fileMap": [
+      {
+        "basePath": "dist",
+        "files": [
+          "bundle*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "bundle.browser.min.js"
+}


### PR DESCRIPTION
Adding mapcreator-api using npm auto-update from @mapcreator/api.

Resolves #1528.