### PR TITLE
Update primevue w/ npm auto-update

### DIFF
--- a/packages/p/primevue.json
+++ b/packages/p/primevue.json
@@ -31,7 +31,9 @@
         "basePath": "",
         "files": [
           "*/*.@(css|js)",
-          "resources/themes/*/*.css"
+          "resources/images/*.png",
+          "resources/themes/*/*.css",
+          "resources/themes/*/fonts/*.@(woff|woff2)"
         ]
       }
     ]


### PR DESCRIPTION
The `primevue` library on cdnjs is **missing all the fonts of the various theme resources.**

Additionally, it is also lacks two pngs that are referenced from `./resources/primevue.[min.]css` in the released npm package files.

---

ps: How does it work for problems like this where missing files are missing in all prior cdnjs resources of a specific lib? When merging this, will your builder CI rebuild all previous versions? (or future versions only? or someone's gonna trigger a build for the last version and call it a day?)