### PR TITLE
Add marked-gfm-heading-id w/ npm auto-update

### DIFF
--- a/packages/m/marked-gfm-heading-id.json
+++ b/packages/m/marked-gfm-heading-id.json
@@ -1,0 +1,33 @@
+{
+  "name": "marked-gfm-heading-id",
+  "filename": "index.umd.min.js",
+  "description": "marked GFM heading ids",
+  "keywords": [
+    "marked",
+    "extension"
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "marked-gfm-heading-id",
+    "fileMap": [
+      {
+        "basePath": "lib",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/markedjs/marked-gfm-heading-id.git"
+  },
+  "authors": [
+    {
+      "name": "Tony Brix",
+      "email": "Tony@Brix.ninja",
+      "url": "https://Tony.Brix.ninja"
+    }
+  ],
+  "license": "MIT"
+}


### PR DESCRIPTION
Marked 5.0.0 deprecated [some options](https://github.com/markedjs/marked/blob/5adcd5321eebd401819b16b621988ae686982f6d/docs/USING_ADVANCED.md#options). [`marked-gfm-heading-id`](https://www.npmjs.com/package/marked-gfm-heading-id) is now an official replacement for options `headerIds` and `headerPrefix`.