### PR TITLE
Add marked-highlight w/ npm auto-update

### DIFF
--- a/packages/m/marked-highlight.json
+++ b/packages/m/marked-highlight.json
@@ -1,0 +1,34 @@
+{
+  "name": "marked-highlight",
+  "filename": "index.umd.min.js",
+  "description": "marked highlight",
+  "keywords": [
+    "marked",
+    "extension",
+    "highlight"
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "marked-highlight",
+    "fileMap": [
+      {
+        "basePath": "lib",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/markedjs/marked-highlight.git"
+  },
+  "authors": [
+    {
+      "name": "Tony Brix",
+      "email": "Tony@Brix.ninja",
+      "url": "https://Tony.Brix.ninja"
+    }
+  ],
+  "license": "MIT"
+}


### PR DESCRIPTION
Marked 5.0.0 deprecated [some options](https://github.com/markedjs/marked/blob/5adcd5321eebd401819b16b621988ae686982f6d/docs/USING_ADVANCED.md#options). [`marked-highlight`](https://www.npmjs.com/package/marked-highlight) is now an official replacement for options `highlight`, `langPrefix` and `callback` (not listed in settings, but mentioned in the [release notes](https://github.com/markedjs/marked/releases/tag/v5.0.0)).