### PR TITLE
Add marked-mangle w/ npm auto-update

### DIFF
--- a/packages/m/marked-mangle.json
+++ b/packages/m/marked-mangle.json
@@ -1,0 +1,34 @@
+{
+  "name": "marked-mangle",
+  "filename": "index.umd.min.js",
+  "description": "marked mangle extension",
+  "keywords": [
+    "marked",
+    "extension",
+    "mangle"
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "marked-mangle",
+    "fileMap": [
+      {
+        "basePath": "lib",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/markedjs/marked-mangle.git"
+  },
+  "authors": [
+    {
+      "name": "Tony Brix",
+      "email": "Tony@Brix.ninja",
+      "url": "https://Tony.Brix.ninja"
+    }
+  ],
+  "license": "MIT"
+}


### PR DESCRIPTION
Marked 5.0.0 deprecated [some options](https://github.com/markedjs/marked/blob/5adcd5321eebd401819b16b621988ae686982f6d/docs/USING_ADVANCED.md#options). [`marked-mangle`](https://www.npmjs.com/package/marked-mangle) is now an official replacement for the `mangle` option.