### PR TITLE
Add marked-base-url w/ npm auto-update

### DIFF
--- a/packages/m/marked-base-url.json
+++ b/packages/m/marked-base-url.json
@@ -1,0 +1,35 @@
+{
+  "name": "marked-base-url",
+  "filename": "index.umd.min.js",
+  "description": "marked base url",
+  "keywords": [
+    "marked",
+    "extension",
+    "base",
+    "url"
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "marked-base-url",
+    "fileMap": [
+      {
+        "basePath": "lib",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/markedjs/marked-base-url.git"
+  },
+  "authors": [
+    {
+      "name": "Tony Brix",
+      "email": "Tony@Brix.ninja",
+      "url": "https://Tony.Brix.ninja"
+    }
+  ],
+  "license": "MIT"
+}


### PR DESCRIPTION
Marked 5.0.0 deprecated [some options](https://github.com/markedjs/marked/blob/5adcd5321eebd401819b16b621988ae686982f6d/docs/USING_ADVANCED.md#options). [`marked-base-url`](https://www.npmjs.com/package/marked-base-url) is now an official replacement for the `baseUrl` option.