### PR TITLE
Add marked-smartypants w/ npm auto-update

### DIFF
--- a/packages/m/marked-smartypants.json
+++ b/packages/m/marked-smartypants.json
@@ -1,0 +1,34 @@
+{
+  "name": "marked-smartypants",
+  "filename": "index.umd.min.js",
+  "description": "marked extension for smartypants",
+  "keywords": [
+    "marked",
+    "extension",
+    "smartypants"
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "marked-smartypants",
+    "fileMap": [
+      {
+        "basePath": "lib",
+        "files": [
+          "*.@(js|mjs)"
+        ]
+      }
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/markedjs/marked-smartypants.git"
+  },
+  "authors": [
+    {
+      "name": "Tony Brix",
+      "email": "Tony@Brix.ninja",
+      "url": "https://Tony.Brix.ninja"
+    }
+  ],
+  "license": "MIT"
+}


### PR DESCRIPTION
Marked 5.0.0 deprecated [some options](https://github.com/markedjs/marked/blob/5adcd5321eebd401819b16b621988ae686982f6d/docs/USING_ADVANCED.md#options). [`marked-smartypants`](https://www.npmjs.com/package/marked-smartypants) is now an official replacement for the `smartypants` option.