### PR TITLE
Add codex/codex-icons/codex-design-tokens w/ npm auto-update

### DIFF
--- a/packages/c/codex-design-tokens.json
+++ b/packages/c/codex-design-tokens.json
@@ -1,0 +1,34 @@
+{
+  "name": "codex-design-tokens",
+  "filename": "theme-wikimedia-ui.css",
+  "description": "design tokens of the Codex design system for Wikimedia",
+  "keywords": [
+    "codex",
+    "design-system",
+    "components",
+    "front-end"
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "@wikimedia/codex-design-tokens",
+    "fileMap": [
+      {
+        "basePath": "dist",
+        "files": [
+          "*.@(css|json)"
+        ]
+      }
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://gerrit.wikimedia.org/r/design/codex.git"
+  },
+  "authors": [
+    {
+      "name": "Wikimedia Foundation Design Systems Team",
+      "url": "https://www.mediawiki.org/wiki/Design_Systems_Team"
+    }
+  ],
+  "license": "GPL-2.0-or-later"
+}

--- a/packages/c/codex-icons.json
+++ b/packages/c/codex-icons.json
@@ -1,0 +1,34 @@
+{
+  "name": "codex-icons",
+  "filename": "codex-icons.umd.js",
+  "description": "icons of the Codex design system for Wikimedia",
+  "keywords": [
+    "codex",
+    "design-system",
+    "components",
+    "front-end"
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "@wikimedia/codex-icons",
+    "fileMap": [
+      {
+        "basePath": "dist",
+        "files": [
+          "*.@(js|mjs|json|svg)"
+        ]
+      }
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://gerrit.wikimedia.org/r/design/codex.git"
+  },
+  "authors": [
+    {
+      "name": "Wikimedia Foundation Design Systems Team",
+      "url": "https://www.mediawiki.org/wiki/Design_Systems_Team"
+    }
+  ],
+  "license": "MIT"
+}

--- a/packages/c/codex-icons.json
+++ b/packages/c/codex-icons.json
@@ -15,7 +15,8 @@
       {
         "basePath": "dist",
         "files": [
-          "*.@(js|mjs|json|svg)"
+          "*.@(js|mjs|json)",
+          "images/*.svg"
         ]
       }
     ]

--- a/packages/c/codex.json
+++ b/packages/c/codex.json
@@ -1,0 +1,34 @@
+{
+  "name": "codex",
+  "filename": "codex.umd.js",
+  "description": "Codex design system for Wikimedia",
+  "keywords": [
+    "codex",
+    "design-system",
+    "components",
+    "front-end"
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "@wikimedia/codex",
+    "fileMap": [
+      {
+        "basePath": "dist",
+        "files": [
+          "*.@(js|mjs|css)"
+        ]
+      }
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://gerrit.wikimedia.org/r/design/codex.git"
+  },
+  "authors": [
+    {
+      "name": "Wikimedia Foundation Design Systems Team",
+      "url": "https://www.mediawiki.org/wiki/Design_Systems_Team"
+    }
+  ],
+  "license": "GPL-2.0-or-later"
+}


### PR DESCRIPTION
[Codex][1] is the design system for Wikimedia. Having it available on cdnjs will be useful for developers of Wikimedia-related tools who want to match the design of Wikimedia sites (see also [T338834][2]).

The unscoped [`codex` npm package][3] has not been updated in over ten years (and as “a simple tool for building static [websites]” probably would not be very useful on cdnjs anyways), so I hope nobody will mind using the unprefixed `codex` name directly for `@wikimedia/codex`. (There seems to be some precedent for this among existing npmjs packages too, such as `angular` for `@angular/core` or `treejs` for `@widgetjs/tree`.)

[1]: https://www.mediawiki.org/wiki/Special:MyLanguage/Codex
[2]: https://phabricator.wikimedia.org/T338834
[3]: https://www.npmjs.com/package/codex