### PR TITLE
Add duckdb-wasm w/ npm auto-update

### DIFF
--- a/packages/d/duckdb-wasm.json
+++ b/packages/d/duckdb-wasm.json
@@ -22,7 +22,12 @@
     "type": "git",
     "url": "git+https://github.com/duckdb/duckdb-wasm.git"
   },
-  "authors": [],
+  "authors": [
+    {
+      "name": "duckdb-wasm contributors",
+      "url": "https://github.com/duckdb/duckdb-wasm/graphs/contributors"
+    }
+  ],
   "autoupdate": {
     "source": "npm",
     "target": "@duckdb/duckdb-wasm",

--- a/packages/d/duckdb-wasm.json
+++ b/packages/d/duckdb-wasm.json
@@ -1,0 +1,40 @@
+{
+  "name": "duckdb-wasm",
+  "description": "DuckDB powered by WebAssembly",
+  "keywords": [
+    "sql",
+    "duckdb",
+    "relational",
+    "database",
+    "data",
+    "query",
+    "wasm",
+    "analytics",
+    "olap",
+    "arrow",
+    "parquet",
+    "json",
+    "csv"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/duckdb/duckdb-wasm#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/duckdb/duckdb-wasm.git"
+  },
+  "authors": [],
+  "autoupdate": {
+    "source": "npm",
+    "target": "@duckdb/duckdb-wasm",
+    "fileMap": [
+      {
+        "basePath": "dist",
+        "files": [
+          "duckdb-browser*.@(js|mjs|cjs)",
+          "*.wasm"
+        ]
+      }
+    ]
+  },
+  "filename": "duckdb-browser.cjs"
+}


### PR DESCRIPTION
Adding duckdb-wasm using npm auto-update from @duckdb/duckdb-wasm.

Resolves #1627.