### PR TITLE
Add dash-core-components w/ npm auto-update

### DIFF
--- a/packages/d/dash-core-components.json
+++ b/packages/d/dash-core-components.json
@@ -1,0 +1,30 @@
+{
+  "name": "dash-core-components",
+  "description": "Core component suite for Dash",
+  "keywords": [],
+  "license": "MIT",
+  "homepage": "https://github.com/plotly/dash",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/plotly/dash.git"
+  },
+  "authors": [
+    {
+      "name": "Chris Parmer",
+      "email": "chris@plotly.com"
+    }
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "dash-core-components",
+    "fileMap": [
+      {
+        "basePath": "dash_core_components",
+        "files": [
+          "dash_core_components*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "dash_core_components.js"
+}

--- a/packages/d/dash-core-components.json
+++ b/packages/d/dash-core-components.json
@@ -1,7 +1,10 @@
 {
   "name": "dash-core-components",
   "description": "Core component suite for Dash",
-  "keywords": [],
+  "keywords": [
+    "plotly",
+    "dash"
+  ],
   "license": "MIT",
   "homepage": "https://github.com/plotly/dash",
   "repository": {


### PR DESCRIPTION
Adding dash-core-components using npm auto-update from dash-core-components.

Resolves (part of) #1629.