### PR TITLE
Add dash-html-components w/ npm auto-update

### DIFF
--- a/packages/d/dash-html-components.json
+++ b/packages/d/dash-html-components.json
@@ -1,0 +1,30 @@
+{
+  "name": "dash-html-components",
+  "description": "Vanilla HTML components for Dash",
+  "keywords": [],
+  "license": "MIT",
+  "homepage": "https://github.com/plotly/dash",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/plotly/dash.git"
+  },
+  "authors": [
+    {
+      "name": "Chris Parmer",
+      "email": "chris@plotly.com"
+    }
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "dash-html-components",
+    "fileMap": [
+      {
+        "basePath": "dash_html_components",
+        "files": [
+          "dash_html_components*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "dash_html_components.min.js"
+}

--- a/packages/d/dash-html-components.json
+++ b/packages/d/dash-html-components.json
@@ -1,7 +1,10 @@
 {
   "name": "dash-html-components",
   "description": "Vanilla HTML components for Dash",
-  "keywords": [],
+  "keywords": [
+    "plotly",
+    "dash"
+  ],
   "license": "MIT",
   "homepage": "https://github.com/plotly/dash",
   "repository": {


### PR DESCRIPTION
Adding dash-html-components using npm auto-update from dash-html-components.

Resolves (part of) #1629.