### PR TITLE
Add dash-table w/ npm auto-update

### DIFF
--- a/packages/d/dash-table.json
+++ b/packages/d/dash-table.json
@@ -1,0 +1,30 @@
+{
+  "name": "dash-table",
+  "description": "Dash table",
+  "keywords": [],
+  "license": "MIT",
+  "homepage": "https://github.com/plotly/dash",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/plotly/dash.git"
+  },
+  "authors": [
+    {
+      "name": "Chris Parmer",
+      "email": "chris@plotly.com"
+    }
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "dash-table",
+    "fileMap": [
+      {
+        "basePath": "dash_table",
+        "files": [
+          "bundle.js"
+        ]
+      }
+    ]
+  },
+  "filename": "bundle.js"
+}

--- a/packages/d/dash-table.json
+++ b/packages/d/dash-table.json
@@ -1,7 +1,10 @@
 {
   "name": "dash-table",
   "description": "Dash table",
-  "keywords": [],
+  "keywords": [
+    "plotly",
+    "dash"
+  ],
   "license": "MIT",
   "homepage": "https://github.com/plotly/dash",
   "repository": {


### PR DESCRIPTION
Adding dash-table using npm auto-update from dash-table.

Resolves (part of) #1629.