### PR TITLE
Add svelte-range-slider-pips w/ npm auto-update

### DIFF
--- a/packages/s/svelte-range-slider-pips.json
+++ b/packages/s/svelte-range-slider-pips.json
@@ -1,0 +1,49 @@
+{
+  "name": "svelte-range-slider-pips",
+  "description": "Multi-Thumb, Accessible, Beautiful Range Slider with Pips",
+  "keywords": [
+    "svelte",
+    "component",
+    "ui",
+    "input",
+    "range",
+    "slider",
+    "thumb",
+    "handle",
+    "min",
+    "max",
+    "accessible",
+    "pretty",
+    "pip",
+    "pips",
+    "notch",
+    "notches",
+    "simey",
+    "simon"
+  ],
+  "license": "MPL-2.0",
+  "homepage": "https://simeydotme.github.io/svelte-range-slider-pips/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/simeydotme/svelte-range-slider-pips"
+  },
+  "authors": [
+    {
+      "name": "Simon Goellner",
+      "email": "simey.me@gmail.com"
+    }
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "svelte-range-slider-pips",
+    "fileMap": [
+      {
+        "basePath": "dist",
+        "files": [
+          "*.@(js|mjs)"
+        ]
+      }
+    ]
+  },
+  "filename": "svelte-range-slider-pips.js"
+}


### PR DESCRIPTION
Adding svelte-range-slider-pips using npm auto-update from svelte-range-slider-pips.

Resolves #1638.