### PR TITLE
Update leaflet.fullscreen w/ npm auto-update

### DIFF
--- a/packages/l/leaflet.fullscreen.json
+++ b/packages/l/leaflet.fullscreen.json
@@ -21,7 +21,7 @@
         "basePath": "",
         "files": [
           "Control.FullScreen*.+(css|js|map)",
-          "icon-fullscreen*.png"
+          "icon-fullscreen.svg"
         ]
       }
     ]


### PR DESCRIPTION
leaflet.fullscreen changed an image asset from png to svg in version 2.2.0