### PR TITLE
Update nunjucks w/ npm auto-update

### DIFF
--- a/packages/n/nunjucks.json
+++ b/packages/n/nunjucks.json
@@ -21,9 +21,6 @@
           "nunjucks*"
         ]
       }
-    ],
-    "ignoreVersions": [
-      "v.1.3.1"
     ]
   },
   "authors": [

--- a/packages/n/nunjucks.json
+++ b/packages/n/nunjucks.json
@@ -12,8 +12,8 @@
   ],
   "license": "BSD-2-Clause",
   "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/mozilla/nunjucks.git",
+    "source": "npm",
+    "target": "nunjucks",
     "fileMap": [
       {
         "basePath": "browser",


### PR DESCRIPTION
Nunjucks stopped bundling files in the Git repository itself and only publishes them as part of the NPM package.

Refs https://github.com/cdnjs/packages/issues/302.