### PR TITLE
Update layui w/ git auto-update

### DIFF
--- a/packages/l/layui.json
+++ b/packages/l/layui.json
@@ -22,7 +22,9 @@
       {
         "basePath": "dist",
         "files": [
-          "**/*"
+          "*.js?(.map)",
+          "css/**/*.css(.map)",
+          "font/*.@(eot|ttf|svg|woff|woff2)"
         ]
       }
     ]

--- a/packages/l/layui.json
+++ b/packages/l/layui.json
@@ -22,9 +22,7 @@
       {
         "basePath": "dist",
         "files": [
-          "*.js?(.map)",
-          "css/**/*.css",
-          "font/*.@(eot|ttf|svg|woff|woff2)"
+          "**/*"
         ]
       }
     ]

--- a/packages/l/layui.json
+++ b/packages/l/layui.json
@@ -23,7 +23,7 @@
         "basePath": "dist",
         "files": [
           "*.js?(.map)",
-          "css/**/*.css(.map)",
+          "css/**/*.css?(.map)",
           "font/*.@(eot|ttf|svg|woff|woff2)"
         ]
       }


### PR DESCRIPTION
The current files matching rule does not include `layui.css.map` (https://cdnjs.com/libraries/layui/2.9.0-beta.1).
All files in the `dist` directory should be included.
ref: https://unpkg.com/browse/layui@2.9.0-beta.1/dist/
