### PR TITLE
Add rapidoc w/ npm auto-update

### DIFF
--- a/packages/r/rapidoc.json
+++ b/packages/r/rapidoc.json
@@ -1,6 +1,6 @@
 {
 	"name": "rapidoc",
-	"filename": "standalone.js",
+	"filename": "rapidoc-min.js",
 	"description": "Custom Element for Open-API spec viewing",
 	"repository": {
 		"type": "git",

--- a/packages/r/rapidoc.json
+++ b/packages/r/rapidoc.json
@@ -8,7 +8,7 @@
 	},
 	"authors": [
 		{
-			"name": "Rapidoc",
+			"name": "Rapidoc"
 		}
 	],
 	"keywords": [

--- a/packages/r/rapidoc.json
+++ b/packages/r/rapidoc.json
@@ -1,0 +1,35 @@
+{
+	"name": "rapidoc",
+	"filename": "standalone.js",
+	"description": "Custom Element for Open-API spec viewing",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/rapi-doc/RapiDoc.git"
+	},
+	"authors": [
+		{
+			"name": "Rapidoc",
+		}
+	],
+	"keywords": [
+		"api",
+    "docs",
+    "documentation",
+    "reference",
+    "component",
+    "openapi",
+    "swagger"
+	],
+	"license": "MIT",
+	"homepage": "https://github.com/rapi-doc/RapiDoc",
+	"autoupdate": {
+		"source": "npm",
+		"target": "rapidoc",
+		"fileMap": [
+			{
+				"basePath": "dist",
+				"files": ["rapidoc-min.js"]
+			}
+		]
+	}
+}


### PR DESCRIPTION
https://www.npmjs.com/package/rapidoc?activeTab=readme

Rapidoc is a popular API documentation builder and generator using OpenAPI files. An alternative to the CDNJS packages swagger-ui and scalar-api-reference