### PR TITLE
Update mathjax w/ npm auto-update

### DIFF
--- a/packages/m/mathjax.json
+++ b/packages/m/mathjax.json
@@ -20,7 +20,6 @@
       {
         "basePath": "",
         "files": [
-          "**/!(node-main.js)",
           "*.js!(node-main.js)",
           "ui/*.js",
           "sre/*.js",

--- a/packages/m/mathjax.json
+++ b/packages/m/mathjax.json
@@ -21,6 +21,13 @@
         "basePath": "",
         "files": [
           "es5/**/!(node-main.js)",
+          "*.js!(node-main.js)",
+          "ui/*.js",
+          "sre/*.js",
+          "adaptors/*.js",
+          "a11y/*.js",
+          "input/*.js",
+          "output/*.js",
           "config/**/*",
           "extensions/**/*",
           "localization/**/*",

--- a/packages/m/mathjax.json
+++ b/packages/m/mathjax.json
@@ -1,6 +1,6 @@
 {
   "name": "mathjax",
-  "filename": "es5/startup.js",
+  "filename": "startup.js",
   "description": "MathJax is an open source JavaScript display engine for mathematics that works in all browsers.",
   "homepage": "http://www.mathjax.org/",
   "keywords": [
@@ -20,7 +20,7 @@
       {
         "basePath": "",
         "files": [
-          "es5/**/!(node-main.js)",
+          "**/!(node-main.js)",
           "*.js!(node-main.js)",
           "ui/*.js",
           "sre/*.js",


### PR DESCRIPTION
Should fix #1669, #1694

As described in #1694 
>MathJax 4.0.0-beta.3~4 does not have es5/ folder but the version before 4.0.0-alpha.1 has it. That caused the error.
I changed the config with `es5` directory in this PR.

But 4.x is still a beta version and there is no stable 4.x release yet, so I'm not sure we should do the update now.
Please merge as appropriate, thanks