### PR TITLE
Update mdui w/ npm auto-update

### DIFF
--- a/packages/m/mdui.json
+++ b/packages/m/mdui.json
@@ -25,7 +25,7 @@
           "mdui.css",
           "mdui.esm.js",
           "mdui.global.js",
-          "locale/*.js"
+          "locales/*.js"
         ]
       }
     ]


### PR DESCRIPTION
Hi, dear cdnjs team,

The `locale` folder name was wrong before, which caused some files to go missing. We are now fixing this issue.

Thank you!