### PR TITLE
Update carbon-charts w/ npm auto-update

### DIFF
--- a/packages/c/carbon-charts.json
+++ b/packages/c/carbon-charts.json
@@ -49,7 +49,7 @@
       {
         "basePath": "dist/umd",
         "files": [
-          "*.js?(.map)"
+          "*.cjs?(.map)"
         ]
       }
     ]

--- a/packages/c/carbon-charts.json
+++ b/packages/c/carbon-charts.json
@@ -35,7 +35,7 @@
     "type": "git",
     "url": "https://github.com/carbon-design-system/carbon-charts/tree/master/packages/core"
   },
-  "filename": "bundle.umd.js",
+  "filename": "bundle.umd.cjs",
   "autoupdate": {
     "source": "npm",
     "target": "@carbon/charts",


### PR DESCRIPTION
## Change
- Carbon Charts started adding .cjs extension in place of .js for UMD files as the package.json's **type** was set to **module** causing Webpack to misidentify the UMD bundles as ESM.
- New naming follows the default that Vite.js uses.