### PR TITLE
Add css-scope-inline w/ git auto-update

### DIFF
--- a/packages/c/css-scope-inline.json
+++ b/packages/c/css-scope-inline.json
@@ -16,7 +16,7 @@
   },
   "autoupdate": {
     "source": "git",
-    "target": "git://github.com/gnat/css-scope-inline.git",
+    "target": "git://github.com/answerdotai/css-scope-inline.git",
     "fileMap": [
       {
         "basePath": "",

--- a/packages/c/css-scope-inline.json
+++ b/packages/c/css-scope-inline.json
@@ -28,7 +28,7 @@
   },
   "authors": [
     {
-      "name": "Nathanael Anderson"
+      "name": "Nathaniel Sabanski"
     }
   ]
 }

--- a/packages/c/css-scope-inline.json
+++ b/packages/c/css-scope-inline.json
@@ -1,5 +1,6 @@
 {
   "name": "css-scope-inline",
+  "filename": "script.min.js",
   "description": "Lightweight CSS scoping for inline styles without a build step",
   "keywords": [
     "css",
@@ -7,9 +8,8 @@
     "inline",
     "styling"
   ],
-  "author": "Nathanael Anderson",
-  "license": "MIT",
   "homepage": "https://github.com/gnat/css-scope-inline",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/gnat/css-scope-inline.git"
@@ -21,9 +21,14 @@
       {
         "basePath": "",
         "files": [
-          "script.js"
+          "script*.js"
         ]
       }
     ]
-  }
+  },
+  "authors": [
+    {
+      "name": "Nathanael Anderson"
+    }
+  ]
 }

--- a/packages/c/css-scope-inline.json
+++ b/packages/c/css-scope-inline.json
@@ -1,0 +1,29 @@
+{
+  "name": "css-scope-inline",
+  "description": "Lightweight CSS scoping for inline styles without a build step",
+  "keywords": [
+    "css",
+    "scope",
+    "inline",
+    "styling"
+  ],
+  "author": "Nathanael Anderson",
+  "license": "MIT",
+  "homepage": "https://github.com/gnat/css-scope-inline",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/gnat/css-scope-inline.git"
+  },
+  "autoupdate": {
+    "source": "git",
+    "target": "git://github.com/gnat/css-scope-inline.git",
+    "fileMap": [
+      {
+        "basePath": "",
+        "files": [
+          "script.js"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adding CSS Scope Inline library to cdnjs. 

- Library: https://github.com/gnat/css-scope-inline
- Auto-update configured for git
- Files to be included: script.js