### PR TITLE
Update date-fns w/ npm auto-update

### DIFF
--- a/packages/d/date-fns.json
+++ b/packages/d/date-fns.json
@@ -1,6 +1,6 @@
 {
   "name": "date-fns",
-  "filename": "date_fns.min.js",
+  "filename": "cdn.min.js",
   "description": "Modern JavaScript date utility library",
   "license": "MIT",
   "keywords": [

--- a/packages/d/date-fns.json
+++ b/packages/d/date-fns.json
@@ -13,19 +13,22 @@
     "url": "https://github.com/date-fns/date-fns.git"
   },
   "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/date-fns/date-fns.git",
+    "source": "npm",
+    "target": "date-fns",
     "fileMap": [
       {
-        "basePath": "dist",
+        "basePath": "",
         "files": [
-          "**/!(*.json)"
+          "**/cdn.*"
         ]
       }
     ],
     "ignoreVersions": [
-      "v.*"
+      "*-*"
     ]
+  },
+  "optimization": {
+    "js": false
   },
   "authors": [
     {

--- a/packages/d/date-fns.json
+++ b/packages/d/date-fns.json
@@ -22,9 +22,6 @@
           "**/cdn.*"
         ]
       }
-    ],
-    "ignoreVersions": [
-      "*-*"
     ]
   },
   "optimization": {


### PR DESCRIPTION
Releases since [2.0.0-alpha0](https://cdnjs.com/libraries/date-fns/2.0.0-alpha0) have not picked up any files; see release [2.20.0](https://cdnjs.com/libraries/date-fns/2.20.0).

After highlighting this with the author, @kossnocorp, in issue date-fns/date-fns#3791, he gave the green light to try to fix it.

I've changed the following:

1. Autoupdate from npm.
2. Pick up files beginning with `cdn.` in all folders.
3. Ignore versions containing a hyphen, as this seems to indicate pre-releases.
4. Don't optimize JS files, as minified versions come with the package

### Note

I could not find documentation for the ignore format, so I based my pattern on examples I found elsewhere.