### PR TITLE
Add livekit-client w/ npm auto-update 

### DIFF
--- a/packages/l/livekit-client.json
+++ b/packages/l/livekit-client.json
@@ -1,5 +1,5 @@
 {
-  "name": "LiveKit Client SDK",
+  "name": "livekit-client",
   "description": "LiveKit Javascript/Typescript SDK, connects to a self- or cloud-hosted LiveKit server, you can quickly build applications like interactive live streaming or video calls with just a few lines of code.",
   "license": "Apache-2.0",
   "keywords": ["livekit", "video", "streaming", "rtc", "webrtc"],

--- a/packages/l/livekit-client.json
+++ b/packages/l/livekit-client.json
@@ -14,7 +14,7 @@
     "fileMap": [
       {
         "basePath": "dist",
-        "files": ["*.js"]
+        "files": ["*.@(js|mjs)"]
       }
     ]
   },

--- a/packages/l/livekit-client.json
+++ b/packages/l/livekit-client.json
@@ -1,0 +1,27 @@
+{
+  "name": "LiveKit Client SDK",
+  "description": "LiveKit Javascript/Typescript SDK, connects to a self- or cloud-hosted LiveKit server, you can quickly build applications like interactive live streaming or video calls with just a few lines of code.",
+  "license": "Apache-2.0",
+  "keywords": ["livekit", "video", "streaming", "rtc", "webrtc"],
+  "filename": "livekit-client.umd.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/livekit/client-sdk-js"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "livekit-client",
+    "fileMap": [
+      {
+        "basePath": "dist",
+        "files": ["*.js"]
+      }
+    ]
+  },
+  "authors": [
+    {
+      "name": "LiveKit",
+      "url": "https://livekit.io"
+    }
+  ]
+}


### PR DESCRIPTION
Adds TS/JS clientside SDK for (self-hosted or cloud) LiveKit servers. [livekit.io](https://livekit.io)

https://www.npmjs.com/package/livekit-client
https://github.com/livekit/client-sdk-js