### PR TITLE
Update element-plus w/ npm auto-update

### DIFF
--- a/packages/e/element-plus.json
+++ b/packages/e/element-plus.json
@@ -23,7 +23,8 @@
       {
         "basePath": "",
         "files": [
-          "theme-chalk/*.css"
+          "theme-chalk/*.css",
+          "theme-chalk/dark/*.css",
         ]
       },
       {
@@ -47,6 +48,9 @@
     },
     {
       "name": "HerringtonDarkholme"
+    },
+    {
+      "name": "huankong233"
     }
   ]
 }

--- a/packages/e/element-plus.json
+++ b/packages/e/element-plus.json
@@ -24,7 +24,7 @@
         "basePath": "",
         "files": [
           "theme-chalk/*.css",
-          "theme-chalk/dark/*.css",
+          "theme-chalk/dark/*.css"
         ]
       },
       {


### PR DESCRIPTION
element-plus has a dark mode

but you need to import this css('element-plus/theme-chalk/dark/css-vars.css')

but there is no such css file in cdnjs

check out here: https://element-plus.org/en-US/guide/dark-mode.html