### PR TITLE
Update planck-js w/ npm auto-update

### DIFF
--- a/packages/p/planck-js.json
+++ b/packages/p/planck-js.json
@@ -16,11 +16,11 @@
   "license": "Zlib",
   "repository": {
     "type": "git",
-    "url": "git://github.com/shakiba/planck.js.git"
+    "url": "git://github.com/piqnt/planck.js.git"
   },
   "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/shakiba/planck.js.git",
+    "source": "npm",
+    "target": "planck",
     "fileMap": [
       {
         "basePath": "dist",


### PR DESCRIPTION
# Update planck-js configuration

This pull request updates the configuration for planck-js to reflect recent changes in the project's repository and distribution method. The current version on cdnjs is outdated.

## Current State

- The latest version on cdnjs is 0.3.x
- The latest version available on npm is 1.0.2
- There are no releases or tags on the GitHub repository

## Changes made:

1. **Updated repository URL** from `shakiba/planck.js` to `piqnt/planck.js`
   - The original repository has been transferred, as evidenced by GitHub's redirect

2. **Changed auto-update source** from git to npm
   - The npm package "planck" is now the primary distribution method
   - This change is necessary because there are no releases or tags on the GitHub repository

3. **Updated auto-update target** to "planck" to match the current npm package name

## Impact

These changes will allow cdnjs to fetch the latest versions of planck-js from the correct source (npm), ensuring users have access to the most up-to-date files. This should bring the version on cdnjs up to 1.0.2 and enable future updates.

## Verification

- The repository transfer was confirmed by checking GitHub redirects
- The npm package information was verified at https://www.npmjs.com/package/planck
- The current outdated state on cdnjs was confirmed at https://cdnjs.com/libraries/planck-js
- The lack of releases and tags on GitHub was verified at https://github.com/piqnt/planck.js

This update should resolve the issue of cdnjs not having access to the latest versions of planck-js, despite the lack of GitHub releases or tags.