### PR TITLE
Update onnxruntime-web w/ npm auto-update

### DIFF
--- a/packages/o/onnxruntime-web.json
+++ b/packages/o/onnxruntime-web.json
@@ -18,7 +18,7 @@
       {
         "basePath": "dist",
         "files": [
-          "*.@(js|wasm)"
+          "*.@(js|mjs|wasm)"
         ]
       }
     ]


### PR DESCRIPTION
starting v 1.19.0 the `/dist` in [npmjs](https://www.npmjs.com/package/onnxruntime-web?activeTab=code) and [jsdelivr](https://www.jsdelivr.com/package/npm/onnxruntime-web?tab=files&path=dist) contains runtime important .mjs files, while these are not yet on [cdnjs](https://cdnjs.com/libraries/onnxruntime-web/1.19.0)

Solving runtime errors:

```
GET https://cdnjs.cloudflare.com/ajax/libs/onnxruntime-web/1.19.0/ort-wasm-simd-threaded.jsep.mjs 404 (Not Found)
```