### PR TITLE
Update lxgw-wenkai-web w/ npm auto-update

### DIFF
--- a/packages/l/lxgw-wenkai-web.json
+++ b/packages/l/lxgw-wenkai-web.json
@@ -23,18 +23,25 @@
         "basePath": "",
         "files": [
           "style.css",
-          "lxgwwenkai-bold/*.woff2",
-          "lxgwwenkai-bold/result.css",
+          "style.min.css",
+          "lxgwwenkai-medium/*.woff2",
+          "lxgwwenkai-medium/result.css",
+          "lxgwwenkai-medium/result.min.css",
           "lxgwwenkai-light/*.woff2",
           "lxgwwenkai-light/result.css",
+          "lxgwwenkai-light/result.min.css",
           "lxgwwenkai-regular/*.woff2",
           "lxgwwenkai-regular/result.css",
-          "lxgwwenkaimono-bold/*.woff2",
-          "lxgwwenkaimono-bold/result.css",
+          "lxgwwenkai-regular/result.min.css",
+          "lxgwwenkaimono-medium/*.woff2",
+          "lxgwwenkaimono-medium/result.css",
+          "lxgwwenkaimono-medium/result.min.css",
           "lxgwwenkaimono-light/*.woff2",
           "lxgwwenkaimono-light/result.css",
+          "lxgwwenkaimono-light/result.min.css",
           "lxgwwenkaimono-regular/*.woff2",
-          "lxgwwenkaimono-regular/result.css"
+          "lxgwwenkaimono-regular/result.css",
+          "lxgwwenkaimono-regular/result.min.css"
         ]
       }
     ]


### PR DESCRIPTION
* Replaced `lxgwwenkai-bold` with `lxgwwenkai-medium`. (Origin font: [LxgwWenKai/v1.500](https://github.com/lxgw/LxgwWenKai/releases/tag/v1.500))
* Replaced `lxgwwenkaimono-bold` with `lxgwwenkaimono-medium`.
* Added `*.min.css` for the `*.css` files.