### PR TITLE
Update algoliasearch w/ npm auto-update

### DIFF
--- a/packages/a/algoliasearch.json
+++ b/packages/a/algoliasearch.json
@@ -1,6 +1,6 @@
 {
   "name": "algoliasearch",
-  "filename": "algoliasearch.min.js",
+  "filename": "algoliasearch.umd.min.js",
   "description": "AlgoliaSearch API JavaScript client",
   "keywords": [
     "algolia",

--- a/packages/a/algoliasearch.json
+++ b/packages/a/algoliasearch.json
@@ -22,7 +22,7 @@
       {
         "basePath": "dist",
         "files": [
-          "*.js"
+          "**/*.@(js?(.map)|d.ts)"
         ]
       }
     ]


### PR DESCRIPTION
Starting from version 5.0, algoliasearch has been generating some JavaScript files in the `dist/lite/builds` directory, such as `dist/lite/builds/browser.umd.js`. The current configuration used by cdnjs, which is:
```json
{
        "basePath": "dist",
        "files": [
          "*.js"
        ]
}
```
does not match these files, resulting in files missing. This Pull Request fixes this issue.