### PR TITLE
Update ag-grid w/ npm auto-update

### DIFF
--- a/packages/a/ag-grid.json
+++ b/packages/a/ag-grid.json
@@ -36,6 +36,9 @@
       }
     ]
   },
+  "optimization": {
+    "js": false
+  },
   "authors": [
     {
       "name": "Niall Crosby",


### PR DESCRIPTION
I've stopped it, minimising the JS files as they're distributed to NPM, resulting in duplicates in cdnjs.

See the files in [cdn-js](https://cdnjs.com/libraries/ag-grid). and compare them to [npm](https://www.npmjs.com/package/ag-grid-community?activeTab=code) (go into the dist folder).