### PR TITLE
Update cdnjs-test-package-git w/ git auto-update

### DIFF
--- a/packages/c/cdnjs-test-package-git.json
+++ b/packages/c/cdnjs-test-package-git.json
@@ -2,6 +2,7 @@
   "name": "cdnjs-test-package-git",
   "description": "cdnjs test package",
   "keywords": ["cdnjs", "test"],
+  "homepage": "https://github.com/simonabadoiu/cdnjs-test-package",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds the missing `homepage` field that is causing the API e2e to fail: https://github.com/cdnjs/api-server/actions/runs/13551018497/job/37874373154

```
   1) /libraries
       Requesting all fields (?fields=*)
         Library object
           is an object with the full set of library properties:
     AssertionError: expected { …(14) } to have property 'homepage'
```

```
cat debug.js

const data = await fetch ('https://api.cdnjs.com/libraries?fields=*').then(r => r.json());
data.results.forEach(lib => {
  if (typeof lib.homepage !== "string") console.log(lib.name);
});

node debug.js

cdnjs-test-package-git
```