### PR TITLE
Update react-bootstrap w/ npm auto-update

### DIFF
--- a/packages/r/react-bootstrap.json
+++ b/packages/r/react-bootstrap.json
@@ -2,11 +2,12 @@
   "name": "react-bootstrap",
   "filename": "react-bootstrap.min.js",
   "homepage": "http://react-bootstrap.github.io/",
-  "description": "Bootstrap 3 components built with React",
+  "description": "Bootstrap components built with React",
   "keywords": [
     "react",
     "ecosystem-react",
     "react-component",
+    "components",
     "bootstrap"
   ],
   "license": "MIT",


### PR DESCRIPTION
Updates some information that has gone out of date.

There was a user in our repo that mentions the CDN doesn't contain the latest version of the package that's hosted on NPM.  I've read through the documentation here and I believe the auto update should be working fine?

The page still shows 2.10.7 as the latest version:
https://cdnjs.com/libraries/react-bootstrap

NPM shows 2.10.9:
https://www.npmjs.com/package/react-bootstrap