### PR TITLE
Add typescript-vfs w/ npm auto-update

### DIFF
--- a/packages/t/typescript-vfs.json
+++ b/packages/t/typescript-vfs.json
@@ -19,7 +19,7 @@
       {
         "basePath": "dist",
         "files": [
-          "**/*"
+          "*.js"
         ]
       }
     ]

--- a/packages/t/typescript-vfs.json
+++ b/packages/t/typescript-vfs.json
@@ -1,4 +1,5 @@
 {
+  "name": "typescript-vfs",
   "description": "A Map based TypeScript Virtual File System.",
   "filename": "vfs.globals.js",
   "homepage": "http://www.typescriptlang.org",
@@ -7,7 +8,6 @@
     "vfs"
   ],
   "license": "MIT",
-  "name": "typescript",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/TypeScript-Website"

--- a/packages/t/typescript-vfs.json
+++ b/packages/t/typescript-vfs.json
@@ -1,6 +1,6 @@
 {
   "description": "A Map based TypeScript Virtual File System.",
-  "filename": "dist/vfs.cjs.production.min.js",
+  "filename": "dist/vfs.globals.js",
   "homepage": "http://www.typescriptlang.org",
   "keywords": [
     "typescript",

--- a/packages/t/typescript-vfs.json
+++ b/packages/t/typescript-vfs.json
@@ -22,10 +22,6 @@
           "**/*"
         ]
       }
-    ],
-    "ignoreVersions": [
-      "*dev*",
-      "*insiders*"
     ]
   },
   "authors": [

--- a/packages/t/typescript-vfs.json
+++ b/packages/t/typescript-vfs.json
@@ -1,6 +1,6 @@
 {
   "description": "A Map based TypeScript Virtual File System.",
-  "filename": "dist/vfs.globals.js",
+  "filename": "vfs.globals.js",
   "homepage": "http://www.typescriptlang.org",
   "keywords": [
     "typescript",

--- a/packages/t/typescript-vfs.json
+++ b/packages/t/typescript-vfs.json
@@ -1,0 +1,36 @@
+{
+  "description": "A Map based TypeScript Virtual File System.",
+  "filename": "dist/vfs.cjs.production.min.js",
+  "homepage": "http://www.typescriptlang.org",
+  "keywords": [
+    "typescript",
+    "vfs"
+  ],
+  "license": "MIT",
+  "name": "typescript",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/TypeScript-Website"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "@typescript/vfs",
+    "fileMap": [
+      {
+        "basePath": "dist",
+        "files": [
+          "**/*"
+        ]
+      }
+    ],
+    "ignoreVersions": [
+      "*dev*",
+      "*insiders*"
+    ]
+  },
+  "authors": [
+    {
+      "name": "Microsoft Corp."
+    }
+  ]
+}


### PR DESCRIPTION
freeCodeCamp is trying to migrate from a npm-based CDN to cdnjs (https://github.com/freeCodeCamp/freeCodeCamp/pull/59291). `@typescript/vfs`, the Map-based TypeScript Virtual File System commonly used for running TypeScript in-browser, is the last piece of the puzzle missing in cdnjs.

The npm weekly download stat of the package is now 600,000+.

cc @huyenltnguyen