### PR TITLE
Add multisynq-client w/ npm auto-update

### DIFF
--- a/packages/m/multisynq-client
+++ b/packages/m/multisynq-client
@@ -1,0 +1,36 @@
+{
+  "name": "multisynq-client",
+  "description": "Real-time multi-user framework for web applications.",
+  "filename": "multisynq-client.min.js",
+  "homepage": "https://multisynq.io",
+  "keywords": [
+    "multisynq",
+    "multiplayer",
+    "multiuser",
+    "collaboration",
+    "realtime",
+    "framework",
+    "webrtc",
+    "croquet"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/multisynq/multisynq-client"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "@multisynq/client",
+    "fileMap": [
+      {
+        "basePath": "bundled",
+        "files": ["multisynq-client.min.js", "multisynq-client.esm.js"]
+      }
+    ]
+  },
+  "authors": [
+    {
+      "name": "Multisynq"
+    }
+  ]
+}


### PR DESCRIPTION
**Package:** `@multisynq/client`  
**NPM:** https://www.npmjs.com/package/@multisynq/client  
**GitHub:** https://github.com/multisynq/multisynq-client (over 200 stars)
**License:** Apache-2.0  

MultiSynq is a real-time collaboration framework for building multi-user web apps without backend servers. It uses deterministic client-side logic with Model/View architecture and pub/sub events to keep users synchronized.

We are getting a lot of requests to make our framework available on Anthropic's Claude Canvas (which only allows imports from cdnjs.cloudflare.com) from developers, educators, and teams who are trying to build real-time multi-user prototypes (eg multiplayer games, shared whiteboards, chat functionality).

The library is actively maintained and stable at v1.0.2.