### PR TITLE
Add temporal-polyfill w/ npm auto-update

### DIFF
--- a/packages/t/temporal-polyfill.json
+++ b/packages/t/temporal-polyfill.json
@@ -1,0 +1,31 @@
+{
+  "name": "temporal-polyfill",
+  "description": "A lightweight polyfill for Temporal, successor to the JavaScript Date object",
+  "filename": "global.min.js",
+  "keywords": [
+    "Temporal",
+    "polyfill",
+    "date",
+    "time"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fullcalendar/temporal-polyfill"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "temporal-polyfill",
+    "fileMap": [
+      {
+        "basePath": "",
+        "files": [
+          "**/*.js"
+        ]
+      }
+    ]
+  },
+  "optimization": {
+    "js": false
+  }
+}

--- a/packages/t/temporal-polyfill.json
+++ b/packages/t/temporal-polyfill.json
@@ -20,7 +20,11 @@
       {
         "basePath": "",
         "files": [
-          "global*.@(js|cjs|d.ts|d.cts)"
+          "global.min.js",
+          "global.esm.js",
+          "index.js",
+          "chunk/classApi.js",
+          "chunk/internal.js"
         ]
       }
     ]

--- a/packages/t/temporal-polyfill.json
+++ b/packages/t/temporal-polyfill.json
@@ -23,8 +23,7 @@
           "global.min.js",
           "global.esm.js",
           "index.js",
-          "chunk/classApi.js",
-          "chunk/internal.js"
+          "chunk/*.js"
         ]
       }
     ]

--- a/packages/t/temporal-polyfill.json
+++ b/packages/t/temporal-polyfill.json
@@ -20,7 +20,7 @@
       {
         "basePath": "",
         "files": [
-          "**/*.js"
+          "global*.@(js|cjs|d.ts|d.cts)"
         ]
       }
     ]

--- a/packages/t/temporal-polyfill.json
+++ b/packages/t/temporal-polyfill.json
@@ -23,7 +23,7 @@
           "global.min.js",
           "global.esm.js",
           "index.js",
-          "chunk/*.js"
+          "chunks/*.js"
         ]
       }
     ]


### PR DESCRIPTION
This PR adds `temporal-polyfill` to cdnjs.

Temporal is shipped in Firefox 139, but not in other major browsers including Chrome and Safari.

It has 266934 weekly downloads which satisfies the requirement.