### PR TITLE
Update Twing "autoupdate" to its proper GitHub repository

### DIFF
--- a/packages/t/twing.json
+++ b/packages/t/twing.json
@@ -15,11 +15,11 @@
     "typescript"
   ],
   "autoupdate": {
-    "source": "npm",
-    "target": "twing",
+    "source": "git",
+    "target": "git://github.com/NightlyCommit/twing-bundle.git",
     "fileMap": [
       {
-        "basePath": "dist",
+        "basePath": "",
         "files": [
           "lib.min.js"
         ]


### PR DESCRIPTION
As discussed [there](https://github.com/cdnjs/cdnjs/issues/14281), I moved the browser-dedicated bundle of Twing to its own GitHub repository, in order to both reduce the size of [twing's npm package](https://www.npmjs.com/package/twing) and still benefit from the autoupdate feature of cdnjs.

Note that I'm not 100% sure what value is expected for `basePath` when the files are located at the root of the project. I set the value to an empty string, please let me know if this is not correct.