### PR TITLE
Add mermaid-layout-elk w/ npm auto-update

### DIFF
--- a/packages/m/mermaid-layout-elk.json
+++ b/packages/m/mermaid-layout-elk.json
@@ -18,7 +18,8 @@
       {
         "basePath": "dist",
         "files": [
-          "**/!(*.html)"
+          "**/*.mjs",
+          "**/*.map"
         ]
       }
     ]
@@ -27,5 +28,8 @@
     {
       "name": "Knut Sveidqvist"
     }
-  ]
+  ],
+  "optimization": {
+    "js": false
+  }
 }

--- a/packages/m/mermaid-layout-elk.json
+++ b/packages/m/mermaid-layout-elk.json
@@ -1,0 +1,31 @@
+{
+  "name": "mermaid-layout-elk",
+  "description": "ELK layout engine for mermaid",
+  "keywords": [
+    "diagram",
+    "markdown",
+    "flowchart"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mermaid-js/mermaid"
+  },
+  "license": "MIT",
+  "autoupdate": {
+    "source": "npm",
+    "target": "@mermaid-js/layout-elk",
+    "fileMap": [
+      {
+        "basePath": "dist",
+        "files": [
+          "**/!(*.html)"
+        ]
+      }
+    ]
+  },
+  "authors": [
+    {
+      "name": "Knut Sveidqvist"
+    }
+  ]
+}


### PR DESCRIPTION
As always, thanks for `cdnjs`!

This adds `@mermaid-js/layout-elk`, which was unvendored from [mermaid](https://github.com/cdnjs/packages/blob/master/packages/m/mermaid.json) somewhere along the line. 

It is ESM-only, and looks like it vendors [elkjs](https://github.com/cdnjs/packages/issues/1803), if that causes any concerns.