### PR TITLE
Add datatables.net-columncontrol{,-*} w/ npm auto-update

### DIFF
--- a/packages/d/datatables.net-columncontrol-bm.json
+++ b/packages/d/datatables.net-columncontrol-bm.json
@@ -1,0 +1,40 @@
+{
+  "name": "datatables.net-columncontrol-bm",
+  "description": "Bulma styling for DataTables ColumnControl",
+  "keywords": [
+    "DataTables",
+    "table",
+    "Bulma"
+  ],
+  "license": "MIT",
+  "homepage": "https://datatables.net/extensions/columncontrol",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-ColumnControl-Bulma.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-columncontrol-bm",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "js/columnControl.bulma.min.js",
+  "authors": [
+    {
+      "name": "SpryMedia Ltd",
+      "url": "http://datatables.net"
+    }
+  ]
+}

--- a/packages/d/datatables.net-columncontrol-bm.json
+++ b/packages/d/datatables.net-columncontrol-bm.json
@@ -17,15 +17,15 @@
     "target": "datatables.net-columncontrol-bm",
     "fileMap": [
       {
-        "basePath": "css",
+        "basePath": "",
         "files": [
-          "*.css"
+          "css/*.css"
         ]
       },
       {
-        "basePath": "js",
+        "basePath": "",
         "files": [
-          "*.js"
+          "js/*.js"
         ]
       }
     ]

--- a/packages/d/datatables.net-columncontrol-bs.json
+++ b/packages/d/datatables.net-columncontrol-bs.json
@@ -17,15 +17,15 @@
     "target": "datatables.net-columncontrol-bs",
     "fileMap": [
       {
-        "basePath": "css",
+        "basePath": "",
         "files": [
-          "*.css"
+          "css/*.css"
         ]
       },
       {
-        "basePath": "js",
+        "basePath": "",
         "files": [
-          "*.js"
+          "js/*.js"
         ]
       }
     ]

--- a/packages/d/datatables.net-columncontrol-bs.json
+++ b/packages/d/datatables.net-columncontrol-bs.json
@@ -1,0 +1,40 @@
+{
+  "name": "datatables.net-columncontrol-bs",
+  "description": "Bootstrap 3 styling for DataTables' ColumnControl",
+  "keywords": [
+    "DataTables",
+    "table",
+    "Bootstrap"
+  ],
+  "license": "MIT",
+  "homepage": "https://datatables.net/extensions/columncontrol",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-ColumnControl-Bootstrap.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-columncontrol-bs",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "js/columnControl.bootstrap.min.js",
+  "authors": [
+    {
+      "name": "SpryMedia Ltd",
+      "url": "http://datatables.net"
+    }
+  ]
+}

--- a/packages/d/datatables.net-columncontrol-bs4.json
+++ b/packages/d/datatables.net-columncontrol-bs4.json
@@ -1,0 +1,40 @@
+{
+  "name": "datatables.net-columncontrol-bs4",
+  "description": "Bootstrap 4 styling for DataTables ColumnControl",
+  "keywords": [
+    "DataTables",
+    "table",
+    "Bootstrap"
+  ],
+  "license": "MIT",
+  "homepage": "https://datatables.net/extensions/columncontrol",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-ColumnControl-Bootstrap4.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-columncontrol-bs4",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "js/columnControl.bootstrap4.min.js",
+  "authors": [
+    {
+      "name": "SpryMedia Ltd",
+      "url": "http://datatables.net"
+    }
+  ]
+}

--- a/packages/d/datatables.net-columncontrol-bs4.json
+++ b/packages/d/datatables.net-columncontrol-bs4.json
@@ -17,15 +17,15 @@
     "target": "datatables.net-columncontrol-bs4",
     "fileMap": [
       {
-        "basePath": "css",
+        "basePath": "",
         "files": [
-          "*.css"
+          "css/*.css"
         ]
       },
       {
-        "basePath": "js",
+        "basePath": "",
         "files": [
-          "*.js"
+          "js/*.js"
         ]
       }
     ]

--- a/packages/d/datatables.net-columncontrol-bs5.json
+++ b/packages/d/datatables.net-columncontrol-bs5.json
@@ -17,15 +17,15 @@
     "target": "datatables.net-columncontrol-bs5",
     "fileMap": [
       {
-        "basePath": "css",
+        "basePath": "",
         "files": [
-          "*.css"
+          "css/*.css"
         ]
       },
       {
-        "basePath": "js",
+        "basePath": "",
         "files": [
-          "*.js"
+          "js/*.js"
         ]
       }
     ]

--- a/packages/d/datatables.net-columncontrol-bs5.json
+++ b/packages/d/datatables.net-columncontrol-bs5.json
@@ -1,0 +1,40 @@
+{
+  "name": "datatables.net-columncontrol-bs5",
+  "description": "Bootstrap 5 styling for DataTables ColumnControl",
+  "keywords": [
+    "DataTables",
+    "table",
+    "Bootstrap"
+  ],
+  "license": "MIT",
+  "homepage": "https://datatables.net/extensions/columncontrol",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-ColumnControl-Bootstrap5.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-columncontrol-bs5",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "js/columnControl.bootstrap5.min.js",
+  "authors": [
+    {
+      "name": "SpryMedia Ltd",
+      "url": "http://datatables.net"
+    }
+  ]
+}

--- a/packages/d/datatables.net-columncontrol-dt.json
+++ b/packages/d/datatables.net-columncontrol-dt.json
@@ -16,15 +16,15 @@
     "target": "datatables.net-columncontrol-dt",
     "fileMap": [
       {
-        "basePath": "css",
+        "basePath": "",
         "files": [
-          "*.css"
+          "css/*.css"
         ]
       },
       {
-        "basePath": "js",
+        "basePath": "",
         "files": [
-          "*.js"
+          "js/*.js"
         ]
       }
     ]

--- a/packages/d/datatables.net-columncontrol-dt.json
+++ b/packages/d/datatables.net-columncontrol-dt.json
@@ -1,0 +1,39 @@
+{
+  "name": "datatables.net-columncontrol-dt",
+  "description": "DataTables default styling for DataTables ColumnControl",
+  "keywords": [
+    "DataTables",
+    "table"
+  ],
+  "license": "MIT",
+  "homepage": "https://datatables.net/extensions/columncontrol",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-ColumnControl-DataTables.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-columncontrol-dt",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "js/columnControl.dataTables.min.js",
+  "authors": [
+    {
+      "name": "SpryMedia Ltd",
+      "url": "http://datatables.net"
+    }
+  ]
+}

--- a/packages/d/datatables.net-columncontrol-jqui.json
+++ b/packages/d/datatables.net-columncontrol-jqui.json
@@ -1,0 +1,40 @@
+{
+  "name": "datatables.net-columncontrol-jqui",
+  "description": "jQuery UI styling for DataTables ColumnControl",
+  "keywords": [
+    "DataTables",
+    "table",
+    "jQuery UI"
+  ],
+  "license": "MIT",
+  "homepage": "https://datatables.net/extensions/columncontrol",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-ColumnControl-jQueryUI.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-columncontrol-jqui",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "js/columnControl.jqueryui.min.js",
+  "authors": [
+    {
+      "name": "SpryMedia Ltd",
+      "url": "http://datatables.net"
+    }
+  ]
+}

--- a/packages/d/datatables.net-columncontrol-jqui.json
+++ b/packages/d/datatables.net-columncontrol-jqui.json
@@ -17,15 +17,15 @@
     "target": "datatables.net-columncontrol-jqui",
     "fileMap": [
       {
-        "basePath": "css",
+        "basePath": "",
         "files": [
-          "*.css"
+          "css/*.css"
         ]
       },
       {
-        "basePath": "js",
+        "basePath": "",
         "files": [
-          "*.js"
+          "js/*.js"
         ]
       }
     ]

--- a/packages/d/datatables.net-columncontrol-se.json
+++ b/packages/d/datatables.net-columncontrol-se.json
@@ -1,0 +1,41 @@
+{
+  "name": "datatables.net-columncontrol-se",
+  "description": "Fomantic UI styling for DataTables ColumnControl",
+  "keywords": [
+    "DataTables",
+    "table",
+    "FomanticUI",
+    "SemanticUI"
+  ],
+  "license": "MIT",
+  "homepage": "https://datatables.net/extensions/columncontrol",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-ColumnControl-SemanticUI.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-columncontrol-se",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "js/columnControl.semanticui.min.js",
+  "authors": [
+    {
+      "name": "SpryMedia Ltd",
+      "url": "http://datatables.net"
+    }
+  ]
+}

--- a/packages/d/datatables.net-columncontrol-se.json
+++ b/packages/d/datatables.net-columncontrol-se.json
@@ -18,15 +18,15 @@
     "target": "datatables.net-columncontrol-se",
     "fileMap": [
       {
-        "basePath": "css",
+        "basePath": "",
         "files": [
-          "*.css"
+          "css/*.css"
         ]
       },
       {
-        "basePath": "js",
+        "basePath": "",
         "files": [
-          "*.js"
+          "js/*.js"
         ]
       }
     ]

--- a/packages/d/datatables.net-columncontrol-zf.json
+++ b/packages/d/datatables.net-columncontrol-zf.json
@@ -17,15 +17,15 @@
     "target": "datatables.net-columncontrol-zf",
     "fileMap": [
       {
-        "basePath": "css",
+        "basePath": "",
         "files": [
-          "*.css"
+          "css/*.css"
         ]
       },
       {
-        "basePath": "js",
+        "basePath": "",
         "files": [
-          "*.js"
+          "js/*.js"
         ]
       }
     ]

--- a/packages/d/datatables.net-columncontrol-zf.json
+++ b/packages/d/datatables.net-columncontrol-zf.json
@@ -1,0 +1,40 @@
+{
+  "name": "datatables.net-columncontrol-zf",
+  "description": "Foundation styling for DataTables ColumnControl",
+  "keywords": [
+    "DataTables",
+    "table",
+    "Foundation"
+  ],
+  "license": "MIT",
+  "homepage": "https://datatables.net/extensions/columncontrol",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-ColumnControl-Foundation.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-columncontrol-zf",
+    "fileMap": [
+      {
+        "basePath": "css",
+        "files": [
+          "*.css"
+        ]
+      },
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "js/columnControl.foundation.min.js",
+  "authors": [
+    {
+      "name": "SpryMedia Ltd",
+      "url": "http://datatables.net"
+    }
+  ]
+}

--- a/packages/d/datatables.net-columncontrol.json
+++ b/packages/d/datatables.net-columncontrol.json
@@ -16,9 +16,9 @@
     "target": "datatables.net-columncontrol",
     "fileMap": [
       {
-        "basePath": "js",
+        "basePath": "",
         "files": [
-          "*.js"
+          "js/*.js"
         ]
       }
     ]

--- a/packages/d/datatables.net-columncontrol.json
+++ b/packages/d/datatables.net-columncontrol.json
@@ -1,0 +1,33 @@
+{
+  "name": "datatables.net-columncontrol",
+  "description": "ColumnControl for DataTables",
+  "keywords": [
+    "DataTables",
+    "table"
+  ],
+  "license": "MIT",
+  "homepage": "https://datatables.net/extensions/columncontrol",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DataTables/Dist-DataTables-ColumnControl.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "datatables.net-columncontrol",
+    "fileMap": [
+      {
+        "basePath": "js",
+        "files": [
+          "*.js"
+        ]
+      }
+    ]
+  },
+  "filename": "js/dataTables.columnControl.min.js",
+  "authors": [
+    {
+      "name": "SpryMedia Ltd",
+      "url": "http://datatables.net"
+    }
+  ]
+}


### PR DESCRIPTION
Also adds the styling support libraries for this package.

I'm very grateful that you already host the `datatables.net` package and a bunch of its support packages. Earlier this year I introduce a new extension for DataTables called "ColumnControl" ([full details in the blog post here](https://datatables.net/blog/2025/columncontrol)). It would be great if you were able to add have this on CDNJS as well.

More generally, you have a lot of the DataTables extensions and styling support packages, but it is not complete. Would you accept a PR to include all of them? I know you have a requirement to have a certain number of npm installs per month, and some of the lesser used styling packages won't met that requirement, but is would allow all combinations of DataTables, its extensions and styles to be used via CDNJS.