### PR TITLE
Update tailwindplus-elements w/ npm auto-update

### DIFF
--- a/packages/t/tailwindplus-elements.json
+++ b/packages/t/tailwindplus-elements.json
@@ -29,6 +29,9 @@
           "*.@(js|d.ts)"
         ]
       }
+    ],
+    "ignoreVersions": [
+      "*insiders*"
     ]
   },
   "optimization": {

--- a/packages/t/tailwindplus-elements.json
+++ b/packages/t/tailwindplus-elements.json
@@ -29,9 +29,6 @@
           "*.@(js|d.ts)"
         ]
       }
-    ],
-    "ignoreVersions": [
-      "*insiders*"
     ]
   },
   "optimization": {

--- a/packages/t/tailwindplus-elements.json
+++ b/packages/t/tailwindplus-elements.json
@@ -26,9 +26,15 @@
       {
         "basePath": "dist",
         "files": [
-          "*.@(js|cjs|d.ts|d.cts)"
+          "*.@(js|d.ts)"
         ]
       }
+    ],
+    "ignoreVersions": [
+      "*insiders*"
     ]
+  },
+  "optimization": {
+    "js": false
   }
 }


### PR DESCRIPTION
- [x] Remove `*.cjs` and `*.d.cts` as they are not whitelisted by CDN and therefore not served.
- [x] ~Exclude _insiders_ builds.~ - This caused the error `autoupdate: Additional property ignoreVersions is not allowed`
- [x] Prevent minification, as the `index.js` file is already minified.