### PR TITLE
Update axios w/ npm auto-update

### DIFF
--- a/packages/a/axios.json
+++ b/packages/a/axios.json
@@ -15,8 +15,8 @@
   ],
   "license": "MIT",
   "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/mzabriskie/axios.git",
+    "source": "npm",
+    "target": "axios",
     "fileMap": [
       {
         "basePath": "dist",


### PR DESCRIPTION
Starting with version `1.7.0`, Axios no longer provides pre-built distributions in its Git repository, but they're still available in the npm package. Therefore, we must switch to the npm source to pull these files.