### PR TITLE
Update butterfly-extsrc w/ npm auto-update

### DIFF
--- a/packages/b/butterfly-extsrc.json
+++ b/packages/b/butterfly-extsrc.json
@@ -33,7 +33,7 @@
         "basePath": "",
         "files": [
           "sharejs/dist/css/*.css",
-          "sharejs/dist/fonts/*.@(eot|svg|ttf|woff)",
+          "sharejs/dist/fonts/*.@(eot|svg|ttf|woff|woff2)",
           "sharejs/dist/js/*.js",
           "metingjs/dist/*.js"
         ]


### PR DESCRIPTION
Version 5.5.2 of `hexo-theme-butterfly` uses the `iconfont.woff2` file. Currently, this file appears to be missing, causing the website to return a 404 error (<https://cdnjs.cloudflare.com/ajax/libs/butterfly-extsrc/1.1.6/sharejs/dist/fonts/iconfont.woff2>).

Resolve #2079