### PR TITLE
Update layui w/ npm auto-update

### DIFF
--- a/packages/l/layui.json
+++ b/packages/l/layui.json
@@ -20,7 +20,7 @@
       {
         "basePath": "dist",
         "files": [
-          "**/*.@(js|css|map)",
+          "{,*/}*.@(js|css|map)",
           "font/*.@(eot|woff2)"
         ]
       }


### PR DESCRIPTION
Hi, I’ve updated some details in `layui.json` to align with the Layui 3 release. (resolves #2082)

**Additionally, I’d like to report an issue:**
Layui released versions `2.12.1` and `2.13.0` last month, but cdnjs still lists version `2.12.0`:

* cdnjs: [https://cdnjs.com/libraries/layui](https://cdnjs.com/libraries/layui)
* Layui releases: [https://github.com/layui/layui/releases](https://github.com/layui/layui/releases)

Please check why the newer versions haven’t been updated automatically. Thanks!