### PR TITLE
Add aws-sdk3-client-scheduler w/ npm auto-update

### DIFF
--- a/packages/a/aws-sdk3-client-scheduler.json
+++ b/packages/a/aws-sdk3-client-scheduler.json
@@ -1,0 +1,35 @@
+{
+  "name": "aws-sdk3-client-scheduler",
+  "description": "AWS SDK3 for JavaScript - Client Scheduler",
+  "keywords": [
+    "api",
+    "amazon",
+    "aws",
+    "eventbridge",
+    "scheduler"
+  ],
+  "autoupdate": {
+    "source": "npm",
+    "target": "aws-sdk/client-scheduler",
+    "fileMap": [
+      {
+        "basePath": "dist-es", 
+        "files": [
+          "*.js",
+          "**/*.js"
+        ]
+      }
+    ]
+  }
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/aws/aws-sdk-js-v3.git"
+  },
+  "license": "Apache-2.0",
+  "authors": [
+    {
+      "name": "Amazon Web Services",
+      "url": "http://aws.amazon.com/"
+    }
+  ]
+}


### PR DESCRIPTION
Add AWS SDK v3 for Client Scheduler package

Source: https://github.com/aws/aws-sdk-js-v3
NPM: https://www.npmjs.com/package/@aws-sdk/client-scheduler
