### PR TITLE
Add accesslint-core w/ npm auto-update

### DIFF
--- a/packages/a/accesslint-core.json
+++ b/packages/a/accesslint-core.json
@@ -1,0 +1,31 @@
+{
+  "name": "accesslint-core",
+  "description": "Pure accessibility rule engine — WCAG audit with zero browser dependencies",
+  "filename": "index.iife.js",
+  "keywords": [
+    "accessibility",
+    "a11y",
+    "wcag",
+    "audit"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/AccessLint/core",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AccessLint/core.git"
+  },
+  "autoupdate": {
+    "source": "npm",
+    "target": "@accesslint/core",
+    "fileMap": [
+      {
+        "basePath": "dist",
+        "files": [
+          "index.iife.js",
+          "index.js",
+          "index.cjs"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds [@accesslint/core](https://www.npmjs.com/package/@accesslint/core) — a pure accessibility rule engine for WCAG auditing with zero browser dependencies.

- npm: https://www.npmjs.com/package/@accesslint/core
- GitHub: https://github.com/AccessLint/core
- License: MIT
- ~3,700 monthly npm downloads