### PR TITLE
Add corti w/ npm auto-update

### DIFF
--- a/packages/c/corti.json
+++ b/packages/c/corti.json
@@ -1,0 +1,35 @@
+{
+  "name": "corti",
+  "description": "Replace window.SpeechRecognition with a mock object and automate your tests",
+  "keywords": [
+    "recognition",
+    "speech",
+    "speechrecognition",
+    "webkitSpeechRecognition",
+    "mock",
+    "test"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/TalAter/Corti",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TalAter/Corti.git"
+  },
+  "filename": "corti.iife.min.js",
+  "autoupdate": {
+    "source": "npm",
+    "target": "corti",
+    "fileMap": [
+      {
+        "basePath": "dist",
+        "files": ["*.@(js|cjs|map)", "*.d.@(ts|cts)"]
+      }
+    ]
+  },
+  "authors": [
+    {
+      "name": "Tal Ater",
+      "url": "https://www.talater.com/"
+    }
+  ]
+}


### PR DESCRIPTION
## Library info

- **Name:** corti
- **NPM:** https://www.npmjs.com/package/corti
- **GitHub:** https://github.com/TalAter/Corti
- **License:** [MIT](https://github.com/TalAter/Corti/blob/master/LICENSE)
- **Downloads:** ~16,000/month on npm

## Description

Corti is a drop-in replacement for `window.SpeechRecognition` that lets you programmatically control and test the Web Speech API in your tests.

## Files

From `dist/`:
- `corti.iife.min.js` (default/primary — browser script tag)
- `corti.js` (ESM)
- `corti.cjs` (CommonJS)
- `corti.d.ts`, `corti.d.cts` (TypeScript declarations)
- Source maps

## Auto-update

Configured via npm auto-update pointing to the `corti` package, `dist` basePath.