### PR TITLE
Update annyang w/ npm auto-update

### DIFF
--- a/packages/a/annyang.json
+++ b/packages/a/annyang.json
@@ -1,31 +1,21 @@
 {
   "name": "annyang",
-  "description": "A javascript library for adding voice commands to your site, using speech recognition",
+  "description": "A JavaScript library for adding voice commands to your site, using speech recognition",
   "homepage": "https://www.talater.com/annyang/",
-  "filename": "annyang.min.js",
+  "filename": "annyang.iife.min.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/TalAter/annyang.git"
   },
-  "keywords": [
-    "annyang",
-    "annyang.js",
-    "speechrecognition",
-    "webkitspeechrecognition",
-    "voice",
-    "speech",
-    "recognition"
-  ],
+  "keywords": ["annyang", "speechrecognition", "voice", "speech", "recognition"],
   "license": "MIT",
   "autoupdate": {
-    "source": "git",
-    "target": "git://github.com/TalAter/annyang.git",
+    "source": "npm",
+    "target": "annyang",
     "fileMap": [
       {
         "basePath": "dist",
-        "files": [
-          "**/*"
-        ]
+        "files": ["annyang.iife.min.js", "annyang.js", "annyang.cjs"]
       }
     ]
   },


### PR DESCRIPTION
annyang v3.0.0 was rewritten with a modern build system. The `dist/` directory is no longer checked into the git repo, it's only included in the npm tarball.

  Changes:
  - `autoupdate.source`: `git` → `npm`
  - `autoupdate.target`: git URL → npm package name
  - `filename`: `annyang.min.`js → `annyang.iife.min.js` (new IIFE build output)
  - `fileMap.files`: explicit list of build outputs instead of `**/*`