### PR TITLE
canvasXpress: fix autoupdate target (git:// → https://)

### DIFF
--- a/packages/c/canvasXpress.json
+++ b/packages/c/canvasXpress.json
@@ -20,7 +20,7 @@
   },
   "autoupdate": {
     "source": "git",
-    "target": "git://github.com/neuhausi/canvasXpress.git",
+    "target": "https://github.com/neuhausi/canvasXpress.git",
     "fileMap": [
       {
         "basePath": "inst/htmlwidgets/lib/canvasXpress",
@@ -38,3 +38,4 @@
     }
   ]
 }
+


### PR DESCRIPTION
The autoupdate.target uses the git:// protocol, which GitHub permanently disabled in 2022. As a result the auto-updater can no longer clone the repo and the library has been frozen at 24.8.1 while upstream is at 67.5. This one-line change switches the target to https://; tags and the fileMap path are already correct, so the updater should backfill the missing versions on the next run.